### PR TITLE
Clean up all grounding and parsing of pvariable expressions

### DIFF
--- a/pyRDDLGym/Core/Compiler/RDDLLevelAnalysis.py
+++ b/pyRDDLGym/Core/Compiler/RDDLLevelAnalysis.py
@@ -139,9 +139,10 @@ class RDDLLevelAnalysis:
             # not a recognized type
             if cpf_type not in VALID_DEPENDENCIES:
                 if cpf_type == 'state-fluent':
+                    PRIME = PlanningModel.NEXT_STATE_SYM
                     raise RDDLInvalidDependencyInCPFError(
                         f'CPF definition for state-fluent <{cpf}> is not valid: '
-                        f'did you mean <{cpf}\'>?')
+                        f'did you mean <{cpf}{PRIME}>?')
                 else:
                     raise RDDLNotImplementedError(
                         f'Type {cpf_type} of CPF <{cpf}> is not valid.')
@@ -169,7 +170,7 @@ class RDDLLevelAnalysis:
             fluent_type = self.rddl.variable_types.get(cpf, cpf)
             if fluent_type == 'state-fluent':
                 fluent_type = 'next-' + fluent_type
-                cpf = cpf + '\''
+                cpf = cpf + PlanningModel.NEXT_STATE_SYM
             if fluent_type in VALID_DEPENDENCIES and cpf not in graph:
                 raise RDDLMissingCPFDefinitionError(
                     f'{fluent_type} CPF <{cpf}> is not defined in cpfs block.')

--- a/pyRDDLGym/Core/Compiler/RDDLLiftedModel.py
+++ b/pyRDDLGym/Core/Compiler/RDDLLiftedModel.py
@@ -107,7 +107,7 @@ class RDDLLiftedModel(PlanningModel):
         
             # variable is new: record its type, parameters and range
             if pvar.is_state_fluent():
-                primed_name = name + '\''
+                primed_name = name + PlanningModel.NEXT_STATE_SYM
             ptypes = pvar.param_types
             if ptypes is None:
                 ptypes = []
@@ -139,13 +139,14 @@ class RDDLLiftedModel(PlanningModel):
     def _extract_states(self):
         
         # get the default value for each grounded state variable
+        PRIME = PlanningModel.NEXT_STATE_SYM
         states, statesranges, nextstates, prevstates = {}, {}, {}, {}
         for pvar in self._AST.domain.pvariables:
             if pvar.is_state_fluent():
                 name, ptypes = pvar.name, pvar.param_types
                 statesranges[name] = pvar.range
-                nextstates[name] = name + '\''
-                prevstates[name + '\''] = name
+                nextstates[name] = name + PRIME
+                prevstates[name + PRIME] = name
                 states[name] = {gname: pvar.default 
                                 for gname in self.ground_names(name, ptypes)}                
         

--- a/pyRDDLGym/Core/Compiler/RDDLModel.py
+++ b/pyRDDLGym/Core/Compiler/RDDLModel.py
@@ -14,6 +14,10 @@ from pyRDDLGym.Core.Parser.expr import Expression, Value
 class PlanningModel(metaclass=ABCMeta):
     '''The base class representing all RDDL domain + instance.
     '''
+    
+    FLUENT_SEP = '___'
+    OBJECT_SEP = '__'
+    NEXT_STATE_SYM = '\''
 
     def __init__(self):
         self._AST = None
@@ -340,28 +344,33 @@ class PlanningModel(metaclass=ABCMeta):
     
     def ground_name(self, name: str, objects: Iterable[str]) -> str:
         '''Given a variable name and list of objects as arguments, produces a 
-        grounded representation <variable>_<obj1>_<obj2>_...
+        grounded representation <variable>___<obj1>__<obj2>__...
         '''
-        is_primed = name.endswith('\'')
+        is_primed = name.endswith(PlanningModel.NEXT_STATE_SYM)
         var = name
         if is_primed:
             var = var[:-1]
         if objects is not None and objects:
-            var += '_' + '_'.join(objects)
+            objects = PlanningModel.OBJECT_SEP.join(objects)
+            var += PlanningModel.FLUENT_SEP + objects
         if is_primed:
-            var += '\''
+            var += PlanningModel.NEXT_STATE_SYM
         return var
     
     def parse(self, expr: str) -> Tuple[str, List[str]]:
-        '''Parses an expression of the form <name> or <name>_<type1>_<type2>...)
+        '''Parses an expression of the form <name> or <name>___<type1>__<type2>...)
         into a tuple of <name>, [<type1>, <type2>, ...].
         '''
-        is_primed = expr.endswith('\'')
+        is_primed = expr.endswith(PlanningModel.NEXT_STATE_SYM)
         if is_primed:
             expr = expr[:-1]
-        var, *objects = expr.split('_')
+        var, *objects = expr.split(PlanningModel.FLUENT_SEP)
+        if objects:
+            if len(objects) != 1:
+                raise RDDLInvalidObjectError(f'Invalid pvariable expression {expr}.')
+            objects = objects[0].split(PlanningModel.OBJECT_SEP)
         if is_primed:
-            var += '\''
+            var += PlanningModel.NEXT_STATE_SYM
         return var, objects
     
     def variations(self, ptypes: Iterable[str]) -> Iterable[Tuple[str, ...]]:

--- a/pyRDDLGym/Core/Grounder/RDDLGrounder.py
+++ b/pyRDDLGym/Core/Grounder/RDDLGrounder.py
@@ -14,8 +14,6 @@ from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLValueOutOfRangeError
 from pyRDDLGym.Core.Compiler.RDDLModel import RDDLGroundedModel
 from pyRDDLGym.Core.Parser.expr import Expression
 
-PRIME = '\''
-
 AGGREG_OP_TO_STRING_DICT = {
     'prod': '*',
     'sum': '+',
@@ -174,11 +172,13 @@ class RDDLGrounder(Grounder):
         return itertools.product(*objects_by_type)
     
     def _append_variation_to_name(self, base_name, variation):
-        return base_name + '_' + '_'.join(variation)
+        objects = RDDLGroundedModel.OBJECT_SEP.join(variation)
+        return base_name + RDDLGroundedModel.FLUENT_SEP + objects
         
     def _generate_grounded_names(self, base_name,
                                  variation_list,
                                  return_grounding_param_dict=False):
+        PRIME = RDDLGroundedModel.NEXT_STATE_SYM
         all_grounded_names = []
         prime_var = PRIME in base_name
         base_name = base_name.strip(PRIME)
@@ -238,6 +238,7 @@ class RDDLGrounder(Grounder):
                 self.cpforder[level] = [pvariable.name]
 
     def _ground_pvariables_and_cpf(self):
+        PRIME = RDDLGroundedModel.NEXT_STATE_SYM
         all_grounded_state_cpfs = []
         all_grounded_interim_cpfs = []
         all_grounded_derived_cpfs = []
@@ -591,6 +592,7 @@ class RDDLGrounder(Grounder):
                     
     # added on Dec 17 (Mike)
     def _extract_variable_information(self):
+        PRIME = RDDLGroundedModel.NEXT_STATE_SYM
         var_params, var_types, var_ranges = {}, {}, {}
         for pvar in self.AST.domain.pvariables:
             objects = pvar.param_types
@@ -605,7 +607,7 @@ class RDDLGrounder(Grounder):
                 if name in var_params:
                     raise RDDLRepeatedVariableError(
                         f'{pvar.fluent_type} <{pvar.name}> has the same name as '
-                        f'another {var_types[name]}.')
+                        f'another pvariable {var_types[name]}.')
                 primed_name = (name + PRIME) if pvar.is_state_fluent() else name
                 var_params[name] = var_params[primed_name] = []        
                 var_types[name] = pvar.fluent_type

--- a/pyRDDLGym/Visualizer/ElevatorViz.py
+++ b/pyRDDLGym/Visualizer/ElevatorViz.py
@@ -47,18 +47,20 @@ class ElevatorVisualizer(StateViz):
         return img
     
     def render(self, state):
+        
         # Get the state information
+        FLUENT_SEP = PlanningModel.FLUENT_SEP
         elev_to_floor = {}
         for e in self._model.objects['elevator']:
             for fl in self._model.objects['floor']:
-                state_key = f"elevator-at-floor_{e}_{fl}"
+                state_key = self._model.ground_name('elevator-at-floor', [e, fl])
                 if state[state_key]:
                     elev_to_floor[e] = fl
         assert len(elev_to_floor) == self._n_elev
-        num_person_waiting_on_floor = 'num-person-waiting_{floor}'
-        num_person_in_elevator = 'num-person-in-elevator_{elevator}'
-        elev_dir_up = 'elevator-dir-up_{elevator}'
-        elev_closed = 'elevator-closed_{elevator}'
+        num_person_waiting_on_floor = 'num-person-waiting' + FLUENT_SEP + '{floor}'
+        num_person_in_elevator = 'num-person-in-elevator' + FLUENT_SEP + '{elevator}'
+        elev_dir_up = 'elevator-dir-up' + FLUENT_SEP + '{elevator}'
+        elev_closed = 'elevator-closed' + FLUENT_SEP + '{elevator}'
         
         # Initialize the canvas
         screen, surf = self.init_canvas(self._figure_size)

--- a/pyRDDLGym/Visualizer/HVACDisplay.py
+++ b/pyRDDLGym/Visualizer/HVACDisplay.py
@@ -47,31 +47,23 @@ class HVACDisplay(StateViz):
 
         # add none-fluents
         for k, v in self._nonfluents.items():
-            if 'RAIN_SHAPE_' in k:
-                point = k.split('_')[2]
-                rain_shape[point] = v
-            elif 'MAX_RES_CAP_' in k:
-                point = k.split('_')[3]
-                max_res_cap[point] = v
-            elif 'UPPER_BOUND_' in k:
-                point = k.split('_')[2]
-                upper_bound[point] = v
-            elif 'LOWER_BOUND_' in k:
-                point = k.split('_')[2]
-                lower_bound[point] = v
-            elif 'RAIN_SHAPE_' in k:
-                point = k.split('_')[2]
-                rain_shape[point] = v
-            elif 'RAIN_SCALE_' in k:
-                point = k.split('_')[2]
-                rain_scale[point] = v
-            elif 'DOWNSTREAM_' in k:
-                point = k.split('_')[1]
-                v = k.split('_')[2]
-                downstream[point].append(v)
-            elif 'SINK_RES_' in k:
-                point = k.split('_')[2]
-                sink_res[point] = v
+            var, objects = self._model.parse(k)
+            if var == 'RAIN_SHAPE':
+                rain_shape[objects[0]] = v
+            elif var == 'MAX_RES_CAP':
+                max_res_cap[objects[0]] = v
+            elif var == 'UPPER_BOUND':
+                upper_bound[objects[0]] = v
+            elif var == 'LOWER_BOUND':
+                lower_bound[objects[0]] = v
+            elif var == 'RAIN_SHAPE':
+                rain_shape[objects[0]] = v
+            elif var == 'RAIN_SCALE':
+                rain_scale[objects[0]] = v
+            elif var == 'DOWNSTREAM':
+                downstream[objects[0]].append(objects[1])
+            elif var == 'SINK_RES':
+                sink_res[objects[0]] = v
 
         # add states
         for k, v in self._states.items():

--- a/pyRDDLGym/Visualizer/MarsRoverViz.py
+++ b/pyRDDLGym/Visualizer/MarsRoverViz.py
@@ -35,37 +35,33 @@ class MarsRoverVisualizer(StateViz):
 
         # style of fluent_p1
         for k, v in self._nonfluents.items():
-            if 'MINERAL-POS-X_' in k:
-                point = k.split('_')[1]
-                mineral_locaiton[point][0] = v
-            elif 'MINERAL-POS-Y_' in k:
-                point = k.split('_')[1]
-                mineral_locaiton[point][1] = v
-            elif 'MINERAL-AREA_' in k:
-                point = k.split('_')[1]
-                mineral_locaiton[point][2] = v
-            elif 'MINERAL-VALUE_' in k:
-                point = k.split('_')[1]
-                mineral_locaiton[point][3] = v
+            var, objects = self._model.parse(k)
+            if var == 'MINERAL-POS-X':
+                mineral_locaiton[objects[0]][0] = v
+            elif var == 'MINERAL-POS-Y':
+                mineral_locaiton[objects[0]][1] = v
+            elif var == 'MINERAL-AREA':
+                mineral_locaiton[objects[0]][2] = v
+            elif var == 'MINERAL-VALUE':
+                mineral_locaiton[objects[0]][3] = v
 
         return {'mineral_location': mineral_locaiton}
     
     def build_states_layout(self, state):
         rover_location = {o: [None, None] for o in self._objects['rover']}
         mineral_harvested = {o: None for o in self._objects['mineral']}
+        
+        for k, v in state.items():
+            var, objects = self._model.parse(k)
+            if var == 'pos-x':
+                rover_location[objects[0]][0] = v
+            elif var == 'pos-y':
+                rover_location[objects[0]][1] = v
 
         for k, v in state.items():
-            if 'pos-x_' in k:
-                point = k.split('_')[1]
-                rover_location[point][0] = v
-            elif 'pos-y_' in k:
-                point = k.split('_')[1]
-                rover_location[point][1] = v
-
-        for k, v in state.items():
-            if 'mineral-harvested_' in k:
-                point = k.split('_')[1]
-                mineral_harvested[point] = v
+            var, objects = self._model.parse(k)
+            if var == 'mineral-harvested':
+                mineral_harvested[objects[0]] = v
 
         return {'mineral_harvested': mineral_harvested,
                 'rover_location': rover_location}

--- a/pyRDDLGym/Visualizer/PowerGenViz.py
+++ b/pyRDDLGym/Visualizer/PowerGenViz.py
@@ -34,21 +34,18 @@ class PowerGenVisualizer(StateViz):
         prod_units_max = {o: None for o in self._objects['plant']}
         prod_change_penalty = {o: None for o in self._objects['plant']}
         cost_per_unit = {o: None for o in self._objects['plant']}
-
+        
         # add none-fluents
         for k, v in self._nonfluents.items():
-            if 'PROD-UNITS-MIN_' in k:
-                point = k.split('_')[1]
-                prod_units_min[point] = v
-            elif 'ROD-UNITS-MAX_' in k:
-                point = k.split('_')[1]
-                prod_units_max[point] = v
-            elif 'PROD-CHANGE-PENALTY_' in k:
-                point = k.split('_')[1]
-                prod_change_penalty[point] = v
-            elif 'COST-PER-UNIT_' in k:
-                point = k.split('_')[1]
-                cost_per_unit[point] = v
+            var, objects = self._model.parse(k)
+            if var == 'PROD-UNITS-MIN':
+                prod_units_min[objects[0]] = v
+            elif var == 'PROD-UNITS-MAX':
+                prod_units_max[objects[0]] = v
+            elif var == 'PROD-CHANGE-PENALTY':
+                prod_change_penalty[objects[0]] = v
+            elif var == 'COST-PER-UNIT':
+                cost_per_unit[objects[0]] = v
 
         return {'prod_units_min': prod_units_min,
                 'prod_units_max': prod_units_max,
@@ -60,9 +57,9 @@ class PowerGenVisualizer(StateViz):
         temperature = None
 
         for k, v in state.items():
-            if 'prevProd_' in k:
-                point = k.split('_')[1]
-                prevProd[point] = v
+            var, objects = self._model.parse(k)
+            if var == 'prevProd':
+                prevProd[objects[0]] = v
             elif 'temperature' in k:
                 temperature = v
         

--- a/pyRDDLGym/Visualizer/RacecarViz.py
+++ b/pyRDDLGym/Visualizer/RacecarViz.py
@@ -27,13 +27,14 @@ class RacecarVisualizer(StateViz):
         self.ax = plt.gca()
         
         # draw boundaries
+        FLUENT_SEP = PlanningModel.FLUENT_SEP
         obj = model.objects['b']
         X1, X2, Y1, Y2 = [], [], [], []
         for o in obj:
-            X1.append(self._nonfluents['X1_' + o])
-            X2.append(self._nonfluents['X2_' + o])
-            Y1.append(self._nonfluents['Y1_' + o])
-            Y2.append(self._nonfluents['Y2_' + o])
+            X1.append(self._nonfluents['X1' + FLUENT_SEP + o])
+            X2.append(self._nonfluents['X2' + FLUENT_SEP + o])
+            Y1.append(self._nonfluents['Y1' + FLUENT_SEP + o])
+            Y2.append(self._nonfluents['Y2' + FLUENT_SEP + o])
         lines = [[(x1, y1), (x2, y2)] for x1, y1, x2, y2 in zip(X1, Y1, X2, Y2)]
         lc = mc.LineCollection(lines, linewidths=2)
         self.ax.add_collection(lc)

--- a/pyRDDLGym/Visualizer/RecSimViz.py
+++ b/pyRDDLGym/Visualizer/RecSimViz.py
@@ -57,18 +57,18 @@ class RecSimVisualizer(StateViz):
         self._creator_index = {p: ind for ind, p in enumerate(creators)}
         self._creator_means = np.zeros((self._num_creators, space_dim))
         self._user_interests = np.zeros((self._num_users, space_dim))
-
+        
         for key, value in self._nonfluents.items():
-            tokens = key.split('_')
-            if tokens[0] == 'CONSUMER-AFFINITY':
+            var, objects = self._model.parse(key)
+            if var == 'CONSUMER-AFFINITY':
                 self._user_interests[
-                    self._user_index[tokens[1]]][
-                        self._feature_index[tokens[2]]] = value
-            elif tokens[0] == 'PROVIDER-COMPETENCE':
-                if tokens[1] == 'pn': continue
+                    self._user_index[objects[0]]][
+                        self._feature_index[objects[1]]] = value
+            elif var == 'PROVIDER-COMPETENCE':
+                if objects[0] == 'pn': continue
                 self._creator_means[
-                    self._creator_index[tokens[1]]][
-                        self._feature_index[tokens[2]]] = value
+                    self._creator_index[objects[0]]][
+                        self._feature_index[objects[1]]] = value
         self._user_plot = None
         self._creator_plot = None
         self._creator_util_scatter = None
@@ -78,12 +78,12 @@ class RecSimVisualizer(StateViz):
         self._user_satisfaction = np.zeros(self._num_users)
         self._creator_satisfaction = np.zeros(self._num_creators)
         for key, value in states.items():
-            tokens = key.split('_')
-            if tokens[0] == 'consumer-satisfaction':
-                self._user_satisfaction[self._user_index[tokens[1]]] = value
-            elif tokens[0] == 'provider-satisfaction':
-                if tokens[1] == 'pn': continue
-                self._creator_satisfaction[self._creator_index[tokens[1]]] = value
+            var, objects = self._model.parse(key)
+            if var == 'consumer-satisfaction':
+                self._user_satisfaction[self._user_index[objects[0]]] = value
+            elif var == 'provider-satisfaction':
+                if objects[0] == 'pn': continue
+                self._creator_satisfaction[self._creator_index[objects[0]]] = value
         return states
     
     def init_canvas(self, figure_size, dpi):

--- a/pyRDDLGym/Visualizer/ReservoirViz.py
+++ b/pyRDDLGym/Visualizer/ReservoirViz.py
@@ -48,31 +48,23 @@ class ReservoirVisualizer(StateViz):
 
         # add none-fluents
         for k, v in self._nonfluents.items():
-            if 'RAIN_SHAPE_' in k:
-                point = k.split('_')[2]
-                rain_shape[point] = v
-            elif 'MAX_RES_CAP_' in k:
-                point = k.split('_')[3]
-                max_res_cap[point] = v
-            elif 'UPPER_BOUND_' in k:
-                point = k.split('_')[2]
-                upper_bound[point] = v
-            elif 'LOWER_BOUND_' in k:
-                point = k.split('_')[2]
-                lower_bound[point] = v
-            elif 'RAIN_SHAPE_' in k:
-                point = k.split('_')[2]
-                rain_shape[point] = v
-            elif 'RAIN_SCALE_' in k:
-                point = k.split('_')[2]
-                rain_scale[point] = v
-            elif 'DOWNSTREAM_' in k:
-                point = k.split('_')[1]
-                v = k.split('_')[2]
-                downstream[point].append(v)
-            elif 'SINK_RES_' in k:
-                point = k.split('_')[2]
-                sink_res[point] = v
+            var, objects = self._model.parse(k)
+            if var == 'RAIN_SHAPE':
+                rain_shape[objects[0]] = v
+            elif var == 'MAX_RES_CAP':
+                max_res_cap[objects[0]] = v
+            elif var == 'UPPER_BOUND':
+                upper_bound[objects[0]] = v
+            elif var == 'LOWER_BOUND':
+                lower_bound[objects[0]] = v
+            elif var == 'RAIN_SHAPE':
+                rain_shape[objects[0]] = v
+            elif var == 'RAIN_SCALE':
+                rain_scale[objects[0]] = v
+            elif var == 'DOWNSTREAM':
+                downstream[objects[0]].append(objects[1])
+            elif var == 'SINK_RES':
+                sink_res[objects[0]] = v
 
         # add states
         for k, v in self._states.items():

--- a/pyRDDLGym/Visualizer/UAVsViz.py
+++ b/pyRDDLGym/Visualizer/UAVsViz.py
@@ -31,37 +31,32 @@ class UAVsVisualizer(StateViz):
     
     def build_nonfluents_layout(self): 
         goal_location = {o: [None, None, None] for o in self._objects['aircraft']}
-
+        
         for k, v in self._nonfluents.items():
-            if 'GOAL-X_' in k:
-                point = k.split('_')[1]
-                goal_location[point][0] = v
-            elif 'GOAL-Y_' in k:
-                point = k.split('_')[1]
-                goal_location[point][1] = v
-            elif 'GOAL-Z_' in k:
-                point = k.split('_')[1]
-                goal_location[point][2] = v
+            var, objects = self._model.parse(k)
+            if var == 'GOAL-X':
+                goal_location[objects[0]][0] = v
+            elif var == 'GOAL-Y':
+                goal_location[objects[0]][1] = v
+            elif var == 'GOAL-Z':
+                goal_location[objects[0]][2] = v
         
         return {'goal_location': goal_location}
     
     def build_states_layout(self, state):
         drone_location = {o: [None, None, None] for o in self._objects['aircraft']}
         velocity = {o: None for o in self._objects['aircraft']}        
-
+        
         for k, v in state.items():
-            if 'pos-x_' in k:
-                point = k.split('_')[1]
-                drone_location[point][0] = v
-            elif 'pos-y_' in k:
-                point = k.split('_')[1]
-                drone_location[point][1] = v
-            elif 'pos-z_' in k:
-                point = k.split('_')[1]
-                drone_location[point][2] = v
-            elif 'vel_' in k:
-                point = k.split('_')[1]
-                velocity[point] = v
+            var, objects = self._model.parse(k)
+            if var == 'pos-x':
+                drone_location[objects[0]][0] = v
+            elif var == 'pos-y':
+                drone_location[objects[0]][1] = v
+            elif var == 'pos-z':
+                drone_location[objects[0]][2] = v
+            elif var == 'vel':
+                velocity[objects[0]] = v
 
         return {'drone_location': drone_location, 'velocity': velocity}
 

--- a/pyRDDLGym/Visualizer/WildfireViz.py
+++ b/pyRDDLGym/Visualizer/WildfireViz.py
@@ -32,12 +32,12 @@ class WildfireVisualizer(StateViz):
     
     def build_nonfluents_layout(self): 
         targets = []
-
+        
         for k, v in self._nonfluents.items():
-            if 'TARGET_' in k:
+            var, objects = self._model.parse(k)
+            if var == 'TARGET':
                 if v == True:
-                    x = k.split("_")[1]
-                    y = k.split("_")[2]
+                    x, y = objects
                     targets.append((x, y))
 
         return {'targets':targets}
@@ -47,15 +47,14 @@ class WildfireVisualizer(StateViz):
         fuel = []
 
         for k, v in state.items():
-            if 'burning_' in k:
+            var, objects = self._model.parse(k)
+            if var == 'burning':
                 if v == True:
-                    x = k.split("_")[1]
-                    y = k.split("_")[2]
+                    x, y = objects
                     burning.append((x, y))
-            if 'out-of-fuel_' in k:
+            if var == 'out-of-fuel':
                 if v == True:
-                    x = k.split("_")[1]
-                    y = k.split("_")[2]
+                    x, y = objects
                     fuel.append((x, y))
         
         return {'burning':burning, 'out-of-fuel':fuel}


### PR DESCRIPTION
- default syntax is now fluent-name___obj1__obj2__..
- each separator ___ and __ are configurable in PlanningModel
- all development should now refer to the fields FLUENT_SEP, OBJECT_SEP and NEXT_STATE_SYM