### PR TITLE
Mikes object enum fixes

### DIFF
--- a/pyRDDLGym/Core/Compiler/RDDLDecompiler.py
+++ b/pyRDDLGym/Core/Compiler/RDDLDecompiler.py
@@ -6,8 +6,7 @@ from pyRDDLGym.Core.Parser.cpf import CPF
 
 class RDDLDecompiler:
     '''Converts AST representation (e.g., Expression) to a string that represents
-    the corresponding expression in RDDL.
-    '''
+    the corresponding expression in RDDL.'''
     
     def decompile_expr(self, expr: Expression) -> str:
         '''Converts an AST expression to a string representing valid RDDL code.
@@ -28,8 +27,7 @@ class RDDLDecompiler:
     
     def decompile_exprs(self, rddl) -> Dict[str, Union[str, Dict[str, str], List[str]]]:
         '''Converts a RDDL model to a dictionary of decompiled expression strings,
-        as they would appear in the domain description file.
-        '''
+        as they would appear in the domain description file.'''
         decompiled = {}
         decompiled['cpfs'] = {name: self.decompile_expr(expr)
                               for (name, (_, expr)) in rddl.cpfs.items()}
@@ -89,7 +87,8 @@ class RDDLDecompiler:
         _, name = expr.etype
         _, params = expr.args 
         if params is not None:
-            params = ((self._decompile(arg, False, 0) if isinstance(arg, Expression) 
+            params = ((self._decompile(arg, False, 0) 
+                       if isinstance(arg, Expression) 
                        else arg)
                       for arg in params)
         return self._symbolic(name, params, aggregation=False)

--- a/pyRDDLGym/Core/Compiler/RDDLLevelAnalysis.py
+++ b/pyRDDLGym/Core/Compiler/RDDLLevelAnalysis.py
@@ -131,7 +131,7 @@ class RDDLLevelAnalysis:
             # warn use of derived fluent
             if cpf_type == 'derived-fluent':
                 warnings.warn(
-                    f'The use of derived-fluent is discouraged in this version, '
+                    f'The use of derived-fluent is discouraged, '
                     f'please change <{cpf}> to interm-fluent.', stacklevel=2)
             
             # not a recognized type
@@ -143,7 +143,7 @@ class RDDLLevelAnalysis:
                         f'did you mean <{cpf}{PRIME}>?')
                 else:
                     raise RDDLNotImplementedError(
-                        f'Type {cpf_type} of CPF <{cpf}> is not valid.')
+                        f'Type <{cpf_type}> of CPF <{cpf}> is not valid.')
             
             # check that all dependencies are valid
             for dep in deps: 
@@ -171,7 +171,8 @@ class RDDLLevelAnalysis:
                 cpf = cpf + PlanningModel.NEXT_STATE_SYM
             if fluent_type in VALID_DEPENDENCIES and cpf not in graph:
                 raise RDDLMissingCPFDefinitionError(
-                    f'{fluent_type} CPF <{cpf}> is not defined in cpfs block.')
+                    f'{fluent_type} CPF <{cpf}> is not defined '
+                    f'in cpfs {{...}} block.')
                     
     # ===========================================================================
     # topological sort

--- a/pyRDDLGym/Core/Compiler/RDDLLevelAnalysis.py
+++ b/pyRDDLGym/Core/Compiler/RDDLLevelAnalysis.py
@@ -95,8 +95,8 @@ class RDDLLevelAnalysis:
             if self.rddl.is_free_variable(name):
                 pass
             
-            # enum literals are ignored
-            elif not pvars and self.rddl.is_literal(name):
+            # objects are ignored
+            elif not pvars and self.rddl.is_object(name):
                 pass
             
             # variable defined in pvariables {..} scope
@@ -106,8 +106,8 @@ class RDDLLevelAnalysis:
                 var_type = self.rddl.variable_types.get(name, None)
                 if var_type is None:
                     raise RDDLUndefinedVariableError(
-                        f'Variable <{name}> is not defined. '
-                        f'Please check expression for CPF <{cpf}>.')
+                        f'Variable <{name}> is not defined in '
+                        f'expression for CPF <{cpf}>.')
                 
                 # if var is a fluent assign it as dependent of cpf
                 elif var_type != 'non-fluent':
@@ -115,12 +115,10 @@ class RDDLLevelAnalysis:
                 
                 # if a nested fluent
                 if pvars is not None:
-                    for arg in pvars:
-                        self._update_call_graph(graph, cpf, arg)
+                    self._update_call_graph(graph, cpf, pvars)
                 
         elif not expr.is_constant_expression():
-            for arg in expr.args:
-                self._update_call_graph(graph, cpf, arg)
+            self._update_call_graph(graph, cpf, expr.args)
     
     # ===========================================================================
     # call graph validation
@@ -133,7 +131,7 @@ class RDDLLevelAnalysis:
             # warn use of derived fluent
             if cpf_type == 'derived-fluent':
                 warnings.warn(
-                    f'The use of derived-fluent is discouraged in this version: '
+                    f'The use of derived-fluent is discouraged in this version, '
                     f'please change <{cpf}> to interm-fluent.', stacklevel=2)
             
             # not a recognized type
@@ -141,7 +139,7 @@ class RDDLLevelAnalysis:
                 if cpf_type == 'state-fluent':
                     PRIME = PlanningModel.NEXT_STATE_SYM
                     raise RDDLInvalidDependencyInCPFError(
-                        f'CPF definition for state-fluent <{cpf}> is not valid: '
+                        f'CPF definition for state-fluent <{cpf}> is not valid, '
                         f'did you mean <{cpf}{PRIME}>?')
                 else:
                     raise RDDLNotImplementedError(
@@ -160,8 +158,8 @@ class RDDLLevelAnalysis:
                 elif not self.allow_synchronous_state and \
                 cpf_type == dep_type == 'next-state-fluent':
                     raise RDDLInvalidDependencyInCPFError(
-                        f'{cpf_type} <{cpf}> cannot depend on {dep_type} <{dep}>. '
-                        f'Set allow_synchronous_state=True to allow this.')                
+                        f'{cpf_type} <{cpf}> cannot depend on {dep_type} <{dep}>, '
+                        f'set allow_synchronous_state=True to allow this.')                
     
     def _validate_cpf_definitions(self, graph): 
         

--- a/pyRDDLGym/Core/Compiler/RDDLLiftedModel.py
+++ b/pyRDDLGym/Core/Compiler/RDDLLiftedModel.py
@@ -104,14 +104,14 @@ class RDDLLiftedModel(PlanningModel):
             if name in var_params:
                 raise RDDLRepeatedVariableError(
                     f'{pvar.fluent_type} <{name}> has the same name as '
-                    f'another {var_types[name]}.')
+                    f'another {var_types[name]} variable.')
                 
             # make sure name does not contain separators
             SEPARATORS = [PlanningModel.FLUENT_SEP, PlanningModel.OBJECT_SEP] 
             for separator in SEPARATORS:
                 if separator in name:
                     raise RDDLInvalidObjectError(
-                        f'Variable name <{name}> contains the '
+                        f'Variable name <{name}> contains an '
                         f'illegal separator {separator}.')
             
             # record its type, parameters and range
@@ -152,8 +152,8 @@ class RDDLLiftedModel(PlanningModel):
                 default = self.object_name(default)
             if prange in self.objects and default not in self.objects[prange]:
                 raise RDDLTypeError(
-                    f'Default value {default} of variable <{name}> '
-                    f'is not an object of type {prange}.')         
+                    f'Default value <{default}> of variable <{name}> '
+                    f'is not an object of type <{prange}>.')         
         return default
     
     def _extract_states(self):
@@ -188,24 +188,25 @@ class RDDLLiftedModel(PlanningModel):
                 gname = self.ground_name(name, params)
                 if gname not in initstates[name]:
                     raise RDDLInvalidObjectError(
-                        f'Parameter(s) {params} of state-fluent {name} '
-                        f'as declared in the init-state block are not valid.')
+                        f'Parameter(s) {params} of state-fluent <{name}> '
+                        f'declared in the init-state block are not valid.')
                 
                 # make sure value is correct type
                 if isinstance(value, str):
                     value = self.object_name(value)
                     value_type = self.objects_rev.get(value, None)
-                    if value_type != statesranges[name]:
+                    required_type = statesranges[name]
+                    if value_type != required_type:
                         if value_type is None:
                             raise RDDLInvalidObjectError(
-                                f'State-fluent <{name}> of type <{statesranges[name]}> '
+                                f'State-fluent <{name}> of type <{required_type}> '
                                 f'is initialized in init-state block with undefined '
                                 f'object <{value}>.')
                         else:
                             raise RDDLInvalidObjectError(
-                                f'State-fluent <{name}> of type <{statesranges[name]}> '
-                                f'is initialized in init-state block with an object '
-                                f'<{value}> of type <{value_type}>.')
+                                f'State-fluent <{name}> of type <{required_type}> '
+                                f'is initialized in init-state block with object '
+                                f'<{value}> of type {value_type}.')
                         
                 initstates[name][gname] = value
                 
@@ -289,18 +290,25 @@ class RDDLLiftedModel(PlanningModel):
                 gname = self.ground_name(name, params)                           
                 if gname not in grounded_names:
                     raise RDDLInvalidObjectError(
-                        f'Parameter(s) {params} of non-fluent {name} '
+                        f'Parameter(s) {params} of non-fluent <{name}> '
                         f'as declared in the non-fluents block are not valid.')
                     
                 # make sure value is correct type
                 if isinstance(value, str):
                     value = self.object_name(value)
                     value_type = self.objects_rev.get(value, None)
-                    if value_type != self.variable_ranges[name]:
-                        raise RDDLInvalidObjectError(
-                            f'Non-fluent <{name}> of type <{self.variable_ranges[name]}> '
-                            f'is initialized in non-fluents block with an object '
-                            f'<{value}> of type <{value_type}>.')
+                    required_type = self.variable_ranges[name]
+                    if value_type != required_type:
+                        if value_type is None:
+                            raise RDDLInvalidObjectError(
+                                f'Non-fluent <{name}> of type <{required_type}> '
+                                f'is initialized in non-fluents block with '
+                                f'undefined object <{value}>')
+                        else:
+                            raise RDDLInvalidObjectError(
+                                f'Non-fluent <{name}> of type <{required_type}> '
+                                f'is initialized in non-fluents block with object '
+                                f'<{value}> of type <{value_type}>.')
                         
                 grounded_names[gname] = value
                                         

--- a/pyRDDLGym/Core/Compiler/RDDLLiftedModel.py
+++ b/pyRDDLGym/Core/Compiler/RDDLLiftedModel.py
@@ -5,6 +5,7 @@ from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLInvalidNumberOfArgume
 from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLInvalidObjectError
 from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLMissingCPFDefinitionError
 from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLRepeatedVariableError
+from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLTypeError
 from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLValueOutOfRangeError
 from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLUndefinedCPFError
 from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLUndefinedVariableError
@@ -13,8 +14,7 @@ from pyRDDLGym.Core.Compiler.RDDLModel import PlanningModel
 
 
 class RDDLLiftedModel(PlanningModel):
-    '''Represents a RDDL domain + instance in lifted form.
-    '''
+    '''Represents a RDDL domain + instance in lifted form.'''
     
     def __init__(self, rddl):
         super(RDDLLiftedModel, self).__init__()
@@ -47,25 +47,27 @@ class RDDLLiftedModel(PlanningModel):
         ast_objects = dict(ast_objects)
         
         # record the set of objects of each type defined in the domain
-        objects, objects_rev = {}, {}
-        enum_types, enum_literals = set(), set()    
+        objects, objects_rev, enums = {}, {}, set() 
         for (name, pvalues) in self._AST.domain.types:
             
-            # object
+            # check duplicated type
+            if name in objects:
+                raise RDDLInvalidObjectError(f'Type <{name}> is repeated.')
+            
+            # instance object
             if pvalues == 'object': 
                 objects[name] = ast_objects.get(name, None)
                 if objects[name] is None:
                     raise RDDLInvalidObjectError(
                         f'Type <{name}> has no objects defined in the instance.')
-            
-            # enumerated type
+                objects[name] = list(map(self.object_name, objects[name]))
+                
+            # domain object
             else: 
-                objects[name] = pvalues
-                enum_types.add(name)
-                enum_literals.update(pvalues)        
+                objects[name] = list(map(self.object_name, pvalues))
+                enums.add(name)
         
-            # make sure types do not share an object
-            # record the type that each object corresponds to
+            # make sure types do not share an object - record type of each object
             for obj in objects[name]:
                 if obj in objects_rev:
                     raise RDDLInvalidObjectError(
@@ -77,24 +79,23 @@ class RDDLLiftedModel(PlanningModel):
         for (ptype, _) in self._AST.non_fluents.objects:
             if ptype not in objects:
                 raise RDDLInvalidObjectError(
-                    f'Type <{ptype}> declared in instance is not declared in '
-                    f'types {{ ... }} domain block.')
+                    f'Type <{ptype}> declared in the instance is not declared in '
+                    f'types {{ ... }} block in the domain.')
         
-        # maps each object to its canonical order as appears in RDDL definition
+        # maps each object to its canonical order as it appears in definition
         objects_index = {obj: i 
                          for objs in objects.values() 
                             for (i, obj) in enumerate(objs)}
         
-        self.objects, self.objects_rev = objects, objects_rev
+        self.objects, self.objects_rev, self.enums = objects, objects_rev, enums
         self.index_of_object = objects_index
-        self.enum_types, self.enum_literals = enum_types, enum_literals
     
     def _extract_variable_information(self):
         
         # extract some basic information about variables in the domain:
-        # 1. their object parameters needed to evaluate
-        # 2. their types (e.g. state-fluent, action-fluent)
-        # 3. their ranges (e.g. int, real, enum-type)
+        # 1. object parameters needed to evaluate
+        # 2. type (e.g. state-fluent, action-fluent)
+        # 3. range (e.g. int, real, bool, type)
         var_params, var_types, var_ranges = {}, {}, {}
         for pvar in self._AST.domain.pvariables: 
             
@@ -113,7 +114,7 @@ class RDDLLiftedModel(PlanningModel):
                         f'Variable name <{name}> contains the '
                         f'illegal separator {separator}.')
             
-            # variable is new: record its type, parameters and range
+            # record its type, parameters and range
             if pvar.is_state_fluent():
                 primed_name = name + PlanningModel.NEXT_STATE_SYM
             ptypes = pvar.param_types
@@ -144,20 +145,32 @@ class RDDLLiftedModel(PlanningModel):
                 new_dict[var] = grounded_names[0]
         return new_dict
     
+    def _extract_default_value(self, pvar):
+        name, prange, default = pvar.name, pvar.range, pvar.default
+        if default is not None:
+            if isinstance(default, str):
+                default = self.object_name(default)
+            if prange in self.objects and default not in self.objects[prange]:
+                raise RDDLTypeError(
+                    f'Default value {default} of variable <{name}> '
+                    f'is not an object of type {prange}.')         
+        return default
+    
     def _extract_states(self):
         
-        # get the default value for each grounded state variable
+        # get the information for each state from the domain
         PRIME = PlanningModel.NEXT_STATE_SYM
         states, statesranges, nextstates, prevstates = {}, {}, {}, {}
         for pvar in self._AST.domain.pvariables:
             if pvar.is_state_fluent():
-                name, ptypes = pvar.name, pvar.param_types
-                statesranges[name] = pvar.range
+                name, ptypes, prange = pvar.name, pvar.param_types, pvar.range
+                statesranges[name] = prange
                 nextstates[name] = name + PRIME
                 prevstates[name + PRIME] = name
-                states[name] = {gname: pvar.default 
-                                for gname in self.ground_names(name, ptypes)}                
-        
+                default = self._extract_default_value(pvar)              
+                states[name] = {gname: default 
+                                for gname in self.ground_names(name, ptypes)} 
+                
         # update the state values with the values in the instance
         initstates = copy.deepcopy(states)
         if hasattr(self._AST.instance, 'init_state'):
@@ -169,13 +182,31 @@ class RDDLLiftedModel(PlanningModel):
                         f'Variable <{name}> referenced in init-state block '
                         f'is not a valid state-fluent.')
                     
-                # extract the grounded name, and check that parameters are valid
+                # extract the grounded name and check that parameters are valid
+                if params is not None:
+                    params = list(map(self.object_name, params))
                 gname = self.ground_name(name, params)
                 if gname not in initstates[name]:
                     raise RDDLInvalidObjectError(
                         f'Parameter(s) {params} of state-fluent {name} '
                         f'as declared in the init-state block are not valid.')
-                    
+                
+                # make sure value is correct type
+                if isinstance(value, str):
+                    value = self.object_name(value)
+                    value_type = self.objects_rev.get(value, None)
+                    if value_type != statesranges[name]:
+                        if value_type is None:
+                            raise RDDLInvalidObjectError(
+                                f'State-fluent <{name}> of type <{statesranges[name]}> '
+                                f'is initialized in init-state block with undefined '
+                                f'object <{value}>.')
+                        else:
+                            raise RDDLInvalidObjectError(
+                                f'State-fluent <{name}> of type <{statesranges[name]}> '
+                                f'is initialized in init-state block with an object '
+                                f'<{value}> of type <{value_type}>.')
+                        
                 initstates[name][gname] = value
                 
         # state dictionary associates the variable lifted name with a list of
@@ -189,14 +220,15 @@ class RDDLLiftedModel(PlanningModel):
         self.init_state = initstates
     
     def _value_list_or_scalar_from_default(self, pvar):
-        ptypes = pvar.param_types
-        default = pvar.default
+        default = self._extract_default_value(pvar)
+        ptypes = pvar.param_types   
         if ptypes is None:
             return default
-        num_variations = 1
-        for ptype in ptypes:
-            num_variations *= len(self.objects[ptype])
-        return [default] * num_variations
+        else:
+            num_variations = 1
+            for ptype in ptypes:
+                num_variations *= len(self.objects[ptype])
+            return [default] * num_variations
     
     def _extract_actions(self):
         
@@ -210,7 +242,7 @@ class RDDLLiftedModel(PlanningModel):
     
     def _extract_derived_and_interm(self):
         
-        # derived/interm are stored similar to states described above
+        # derived and interm are stored similar to states described above
         derived, interm = {}, {}
         for pvar in self._AST.domain.pvariables:
             if pvar.is_derived_fluent():
@@ -236,7 +268,8 @@ class RDDLLiftedModel(PlanningModel):
         for pvar in self._AST.domain.pvariables:
             if pvar.is_non_fluent():
                 name, ptypes = pvar.name, pvar.param_types
-                non_fluents[name] = {gname: pvar.default
+                default = self._extract_default_value(pvar)      
+                non_fluents[name] = {gname: default
                                      for gname in self.ground_names(name, ptypes)}
         
         # update non-fluent values with the values in the instance
@@ -250,13 +283,25 @@ class RDDLLiftedModel(PlanningModel):
                         f'Variable <{name}> referenced in non-fluents block '
                         f'is not a valid non-fluent.')
                 
-                # extract the grounded name, and check that parameters are valid
+                # extract the grounded name and check that parameters are valid
+                if params is not None:
+                    params = list(map(self.object_name, params))
                 gname = self.ground_name(name, params)                           
                 if gname not in grounded_names:
                     raise RDDLInvalidObjectError(
                         f'Parameter(s) {params} of non-fluent {name} '
                         f'as declared in the non-fluents block are not valid.')
-                
+                    
+                # make sure value is correct type
+                if isinstance(value, str):
+                    value = self.object_name(value)
+                    value_type = self.objects_rev.get(value, None)
+                    if value_type != self.variable_ranges[name]:
+                        raise RDDLInvalidObjectError(
+                            f'Non-fluent <{name}> of type <{self.variable_ranges[name]}> '
+                            f'is initialized in non-fluents block with an object '
+                            f'<{value}> of type <{value_type}>.')
+                        
                 grounded_names[gname] = value
                                         
         # non-fluents are stored similar to states described above
@@ -318,8 +363,7 @@ class RDDLLiftedModel(PlanningModel):
     def _extract_max_actions(self):
         numactions = getattr(self._AST.instance, 'max_nondef_actions', 'pos-inf')
         if numactions == 'pos-inf':
-            self.max_allowed_actions = sum(np.size(action) 
-                                           for action in self.actions.values())
+            self.max_allowed_actions = sum(map(np.size, self.actions.values()))
         else:
             self.max_allowed_actions = int(numactions)
 

--- a/pyRDDLGym/Core/Compiler/RDDLLiftedModel.py
+++ b/pyRDDLGym/Core/Compiler/RDDLLiftedModel.py
@@ -42,7 +42,7 @@ class RDDLLiftedModel(PlanningModel):
         
         # objects of each type as defined in the non-fluents {..} block
         ast_objects = self._AST.non_fluents.objects
-        if (not ast_objects) or ast_objects[0] is None:
+        if not ast_objects or ast_objects[0] is None:
             ast_objects = []
         ast_objects = dict(ast_objects)
         
@@ -52,7 +52,8 @@ class RDDLLiftedModel(PlanningModel):
             
             # check duplicated type
             if name in objects:
-                raise RDDLInvalidObjectError(f'Type <{name}> is repeated.')
+                raise RDDLInvalidObjectError(
+                    f'Type <{name}> is repeated in types block.')
             
             # instance object
             if pvalues == 'object': 
@@ -76,19 +77,18 @@ class RDDLLiftedModel(PlanningModel):
                 objects_rev[obj] = name
         
         # check that all types in instance are declared in domain
-        for (ptype, _) in self._AST.non_fluents.objects:
+        for ptype in ast_objects:
             if ptype not in objects:
                 raise RDDLInvalidObjectError(
-                    f'Type <{ptype}> declared in the instance is not declared in '
-                    f'types {{ ... }} block in the domain.')
+                    f'Type <{ptype}> defined in the instance is not declared in '
+                    f'the domain.')
         
         # maps each object to its canonical order as it appears in definition
-        objects_index = {obj: i 
-                         for objs in objects.values() 
-                            for (i, obj) in enumerate(objs)}
+        self.index_of_object = {obj: i 
+                                for objs in objects.values() 
+                                    for (i, obj) in enumerate(objs)}
         
         self.objects, self.objects_rev, self.enums = objects, objects_rev, enums
-        self.index_of_object = objects_index
     
     def _extract_variable_information(self):
         
@@ -127,12 +127,11 @@ class RDDLLiftedModel(PlanningModel):
             var_ranges[name] = var_ranges[primed_name] = pvar.range    
         
         # maps each variable (as appears in RDDL) to list of grounded variations
-        var_grounded = {var: list(self.ground_names(var, types))
-                        for (var, types) in var_params.items()}        
+        self.grounded_names = {var: list(self.ground_names(var, types))
+                               for (var, types) in var_params.items()}        
         
         self.param_types, self.variable_types, self.variable_ranges = \
             var_params, var_types, var_ranges
-        self.grounded_names = var_grounded
     
     def _grounded_dict_to_dict_of_list(self, grounded_dict):
         new_dict = {}
@@ -146,13 +145,13 @@ class RDDLLiftedModel(PlanningModel):
         return new_dict
     
     def _extract_default_value(self, pvar):
-        name, prange, default = pvar.name, pvar.range, pvar.default
+        prange, default = pvar.range, pvar.default
         if default is not None:
             if isinstance(default, str):
                 default = self.object_name(default)
             if prange in self.objects and default not in self.objects[prange]:
                 raise RDDLTypeError(
-                    f'Default value <{default}> of variable <{name}> '
+                    f'Default value <{default}> of variable <{pvar.name}> '
                     f'is not an object of type <{prange}>.')         
         return default
     
@@ -163,8 +162,8 @@ class RDDLLiftedModel(PlanningModel):
         states, statesranges, nextstates, prevstates = {}, {}, {}, {}
         for pvar in self._AST.domain.pvariables:
             if pvar.is_state_fluent():
-                name, ptypes, prange = pvar.name, pvar.param_types, pvar.range
-                statesranges[name] = prange
+                name, ptypes = pvar.name, pvar.param_types
+                statesranges[name] = pvar.range
                 nextstates[name] = name + PRIME
                 prevstates[name + PRIME] = name
                 default = self._extract_default_value(pvar)              
@@ -173,42 +172,42 @@ class RDDLLiftedModel(PlanningModel):
                 
         # update the state values with the values in the instance
         initstates = copy.deepcopy(states)
-        if hasattr(self._AST.instance, 'init_state'):
-            for ((name, params), value) in self._AST.instance.init_state:
+        init_state_info = getattr(self._AST.instance, 'init_state', [])
+        for ((name, params), value) in init_state_info:
                 
-                # check whether name is a valid state-fluent
-                if name not in initstates:
-                    raise RDDLUndefinedVariableError(
-                        f'Variable <{name}> referenced in init-state block '
-                        f'is not a valid state-fluent.')
+            # check whether name is a valid state-fluent
+            if name not in initstates:
+                raise RDDLUndefinedVariableError(
+                    f'Variable <{name}> referenced in init-state block '
+                    f'is not a valid state-fluent.')
                     
-                # extract the grounded name and check that parameters are valid
-                if params is not None:
-                    params = list(map(self.object_name, params))
-                gname = self.ground_name(name, params)
-                if gname not in initstates[name]:
-                    raise RDDLInvalidObjectError(
-                        f'Parameter(s) {params} of state-fluent <{name}> '
-                        f'declared in the init-state block are not valid.')
+            # extract the grounded name and check that parameters are valid
+            if params is not None:
+                params = list(map(self.object_name, params))
+            gname = self.ground_name(name, params)
+            if gname not in initstates[name]:
+                raise RDDLInvalidObjectError(
+                    f'Parameter(s) {params} of state-fluent <{name}> '
+                    f'declared in the init-state block are not valid.')
                 
-                # make sure value is correct type
-                if isinstance(value, str):
-                    value = self.object_name(value)
-                    value_type = self.objects_rev.get(value, None)
-                    required_type = statesranges[name]
-                    if value_type != required_type:
-                        if value_type is None:
-                            raise RDDLInvalidObjectError(
-                                f'State-fluent <{name}> of type <{required_type}> '
-                                f'is initialized in init-state block with undefined '
-                                f'object <{value}>.')
-                        else:
-                            raise RDDLInvalidObjectError(
-                                f'State-fluent <{name}> of type <{required_type}> '
-                                f'is initialized in init-state block with object '
-                                f'<{value}> of type {value_type}.')
+            # make sure value is correct type
+            if isinstance(value, str):
+                value = self.object_name(value)
+                value_type = self.objects_rev.get(value, None)
+                required_type = statesranges[name]
+                if value_type != required_type:
+                    if value_type is None:
+                        raise RDDLInvalidObjectError(
+                            f'State-fluent <{name}> of type <{required_type}> '
+                            f'is initialized in init-state block with undefined '
+                            f'object <{value}>.')
+                    else:
+                        raise RDDLInvalidObjectError(
+                            f'State-fluent <{name}> of type <{required_type}> '
+                            f'is initialized in init-state block with object '
+                            f'<{value}> of type {value_type}.')
                         
-                initstates[name][gname] = value
+            initstates[name][gname] = value
                 
         # state dictionary associates the variable lifted name with a list of
         # values for all variations of parameter arguments in C-based order
@@ -274,43 +273,43 @@ class RDDLLiftedModel(PlanningModel):
                                      for gname in self.ground_names(name, ptypes)}
         
         # update non-fluent values with the values in the instance
-        if hasattr(self._AST.non_fluents, 'init_non_fluent'):
-            for ((name, params), value) in self._AST.non_fluents.init_non_fluent:
+        non_fluent_info = getattr(self._AST.non_fluents, 'init_non_fluent', [])
+        for ((name, params), value) in non_fluent_info:
                 
-                # check whether name is a valid non-fluent
-                grounded_names = non_fluents.get(name, None)
-                if grounded_names is None:
-                    raise RDDLUndefinedVariableError(
-                        f'Variable <{name}> referenced in non-fluents block '
-                        f'is not a valid non-fluent.')
+            # check whether name is a valid non-fluent
+            grounded_names = non_fluents.get(name, None)
+            if grounded_names is None:
+                raise RDDLUndefinedVariableError(
+                    f'Variable <{name}> referenced in non-fluents block '
+                    f'is not a valid non-fluent.')
                 
-                # extract the grounded name and check that parameters are valid
-                if params is not None:
-                    params = list(map(self.object_name, params))
-                gname = self.ground_name(name, params)                           
-                if gname not in grounded_names:
-                    raise RDDLInvalidObjectError(
-                        f'Parameter(s) {params} of non-fluent <{name}> '
-                        f'as declared in the non-fluents block are not valid.')
+            # extract the grounded name and check that parameters are valid
+            if params is not None:
+                params = list(map(self.object_name, params))
+            gname = self.ground_name(name, params)                           
+            if gname not in grounded_names:
+                raise RDDLInvalidObjectError(
+                    f'Parameter(s) {params} of non-fluent <{name}> '
+                    f'as declared in the non-fluents block are not valid.')
                     
-                # make sure value is correct type
-                if isinstance(value, str):
-                    value = self.object_name(value)
-                    value_type = self.objects_rev.get(value, None)
-                    required_type = self.variable_ranges[name]
-                    if value_type != required_type:
-                        if value_type is None:
-                            raise RDDLInvalidObjectError(
-                                f'Non-fluent <{name}> of type <{required_type}> '
-                                f'is initialized in non-fluents block with '
-                                f'undefined object <{value}>')
-                        else:
-                            raise RDDLInvalidObjectError(
-                                f'Non-fluent <{name}> of type <{required_type}> '
-                                f'is initialized in non-fluents block with object '
-                                f'<{value}> of type <{value_type}>.')
+            # make sure value is correct type
+            if isinstance(value, str):
+                value = self.object_name(value)
+                value_type = self.objects_rev.get(value, None)
+                required_type = self.variable_ranges[name]
+                if value_type != required_type:
+                    if value_type is None:
+                        raise RDDLInvalidObjectError(
+                            f'Non-fluent <{name}> of type <{required_type}> '
+                            f'is initialized in non-fluents block with '
+                            f'undefined object <{value}>.')
+                    else:
+                        raise RDDLInvalidObjectError(
+                            f'Non-fluent <{name}> of type <{required_type}> '
+                            f'is initialized in non-fluents block with object '
+                            f'<{value}> of type <{value_type}>.')
                         
-                grounded_names[gname] = value
+            grounded_names[gname] = value
                                         
         # non-fluents are stored similar to states described above
         self.nonfluents = self._grounded_dict_to_dict_of_list(non_fluents)
@@ -351,15 +350,9 @@ class RDDLLiftedModel(PlanningModel):
         self.cpfs = cpfs
     
     def _extract_constraints(self):
-        terminals, preconds, invariants = [], [], []
-        if hasattr(self._AST.domain, 'terminals'):
-            terminals = self._AST.domain.terminals
-        if hasattr(self._AST.domain, 'preconds'):
-            preconds = self._AST.domain.preconds
-        if hasattr(self._AST.domain, 'invariants'):
-            invariants = self._AST.domain.invariants
-        self.terminals, self.preconditions, self.invariants = \
-            terminals, preconds, invariants
+        self.terminals = getattr(self._AST.domain, 'terminals', [])
+        self.preconditions = getattr(self._AST.domain, 'preconds', [])
+        self.invariants = getattr(self._AST.domain, 'invariants', [])
 
     def _extract_horizon(self):
         horizon = self._AST.instance.horizon

--- a/pyRDDLGym/Core/Compiler/RDDLModel.py
+++ b/pyRDDLGym/Core/Compiler/RDDLModel.py
@@ -30,8 +30,7 @@ class PlanningModel(metaclass=ABCMeta):
         self._actions = None
         self._objects = None
         self._objects_rev = None
-        self._enum_types = None
-        self._enum_literals = None
+        self._enums = None
         self._actionsranges = None
         self._derived = None
         self._interm = None
@@ -83,20 +82,12 @@ class PlanningModel(metaclass=ABCMeta):
         self._objects_rev = value
     
     @property
-    def enum_types(self):
-        return self._enum_types
+    def enums(self):
+        return self._enums
 
-    @enum_types.setter
-    def enum_types(self, value):
-        self._enum_types = value
-    
-    @property
-    def enum_literals(self):
-        return self._enum_literals
-
-    @enum_literals.setter
-    def enum_literals(self, value):
-        self._enum_literals = value
+    @enums.setter
+    def enums(self, value):
+        self._enums = value
     
     @property
     def nonfluents(self):
@@ -344,8 +335,7 @@ class PlanningModel(metaclass=ABCMeta):
     
     def ground_name(self, name: str, objects: Iterable[str]) -> str:
         '''Given a variable name and list of objects as arguments, produces a 
-        grounded representation <variable>___<obj1>__<obj2>__...
-        '''
+        grounded representation <variable>___<obj1>__<obj2>__...'''
         PRIME = PlanningModel.NEXT_STATE_SYM
         is_primed = name.endswith(PRIME)
         var = name
@@ -360,8 +350,7 @@ class PlanningModel(metaclass=ABCMeta):
     
     def parse(self, expr: str) -> Tuple[str, List[str]]:
         '''Parses an expression of the form <name> or <name>___<type1>__<type2>...)
-        into a tuple of <name>, [<type1>, <type2>, ...].
-        '''
+        into a tuple of <name>, [<type1>, <type2>, ...].'''
         PRIME = PlanningModel.NEXT_STATE_SYM
         is_primed = expr.endswith(PRIME)
         if is_primed:
@@ -377,8 +366,7 @@ class PlanningModel(metaclass=ABCMeta):
     
     def variations(self, ptypes: Iterable[str]) -> Iterable[Tuple[str, ...]]:
         '''Given a list of types, computes the Cartesian product of all object
-        enumerations that corresponds to those types.
-        '''
+        enumerations that corresponds to those types.'''
         if ptypes is None or not ptypes:
             return [()]
         objects_by_type = []
@@ -394,8 +382,7 @@ class PlanningModel(metaclass=ABCMeta):
     def ground_names(self, name: str, ptypes: Iterable[str]) -> Iterable[str]:
         '''Given a variable name and list of types, produces a new iterator
         whose elements are the grounded representations in the cartesian product 
-        of all object enumerations that corresponds to those types.
-        '''
+        of all object enumerations that corresponds to those types.'''
         for objects in self.variations(ptypes):
             yield self.ground_name(name, objects)
     
@@ -403,39 +390,39 @@ class PlanningModel(metaclass=ABCMeta):
         '''Determines whether the quantity is a free variable (e.g., ?x).'''
         return name[0] == '?'
         
-    def is_literal(self, name: str, msg='') -> bool:
-        '''Determines whether the quantity with the given name is a literal
-        (e.g., an object) belonging to an enum type.
-        '''
-        
-        # this must be a literal
+    def object_name(self, name: str) -> str:
+        '''Extracts the internal object name representation. 
+        Used to read objects with string quantification, e.g. @obj.'''
         if name[0] == '@':
-            if name not in self.enum_literals:
+            name = name[1:]
+        return name
+        
+    def is_object(self, name: str, msg='') -> bool:
+        '''Determines whether the given string points to an object.'''
+        
+        # this must be an object
+        if name[0] == '@':
+            name = name[1:]
+            if name not in self.objects_rev:
                 raise RDDLInvalidObjectError(
-                    f'Literal <{name}> is not defined, '
-                    f'must be one of {self.enum_literals}. {msg}')
+                    f'Object <{name}> is not defined. {msg}')
             return True
         
-        # this could either be a literal or variable
-        # literal if a variable does not exist with the same name
-        # literal if a variable has the same name but free parameters
+        # this could either be an object or variable
+        # object if a variable does not exist with the same name
+        # object if a variable has the same name but free parameters
         # ambiguous if a variable has the same name but no free parameters
-        literal = '@' + name
-        if literal in self.enum_literals:
+        if name in self.objects_rev:
             params = self.param_types.get(name, None)
             if params is not None and not params:
                 raise RDDLInvalidObjectError(
-                    f'Ambiguous reference to literal <{literal}> or '
-                    f'variable <{name}> with no parameters. {msg}')
+                    f'Ambiguous reference to object or '
+                    f'parameter-free variable with same name <{name}>. {msg}')
             return True
         
         # this must be a variable or free parameter
         return False
     
-    def literal_name(self, name: str) -> str:
-        '''Prepends @ to the given name if it is not already present.'''
-        return name if name[0] == '@' else ('@' + name)
-        
     def is_compatible(self, var: str, objects: List[str]) -> bool:
         '''Determines whether or not the given variable can be evaluated
         for the given list of objects.'''
@@ -477,8 +464,8 @@ class PlanningModel(metaclass=ABCMeta):
             if self.is_free_variable(name):
                 return True
                 
-            # enum literal is non-fluent
-            elif not pvars and self.is_literal(name):
+            # an object is non-fluent
+            elif not pvars and self.is_object(name):
                 return True
                         
             # variable must be well-defined and non-fluent

--- a/pyRDDLGym/Core/Compiler/RDDLModel.py
+++ b/pyRDDLGym/Core/Compiler/RDDLModel.py
@@ -417,7 +417,7 @@ class PlanningModel(metaclass=ABCMeta):
             if params is not None and not params:
                 raise RDDLInvalidObjectError(
                     f'Ambiguous reference to object or '
-                    f'parameter-free variable with same name <{name}>. {msg}')
+                    f'parameter-free variable with identical name <{name}>. {msg}')
             return True
         
         # this must be a variable or free parameter

--- a/pyRDDLGym/Core/Compiler/RDDLObjectsTracer.py
+++ b/pyRDDLGym/Core/Compiler/RDDLObjectsTracer.py
@@ -48,6 +48,7 @@ class RDDLObjectsTracer:
     '''Performs static/compile-time tracing of a RDDL AST representation and
     annotates nodes with info about objects that appear inside expressions.'''
     
+    # for multivariate sampling: how many dimensions sample has
     REQUIRED_DIST_PVARS = {
         'MultivariateNormal': 1,
         'MultivariateStudent': 1,
@@ -55,6 +56,7 @@ class RDDLObjectsTracer:
         'Multinomial': 1
     }
     
+    # for multivariate sampling: how many _ identifiers each argument has
     REQUIRED_DIST_UNDERSCORES = {
         'MultivariateNormal': (1, 2),  # mean, covariance
         'MultivariateStudent': (1, 2, 0),  # mean, covariance, df

--- a/pyRDDLGym/Core/Env/RDDLEnv.py
+++ b/pyRDDLGym/Core/Env/RDDLEnv.py
@@ -70,7 +70,7 @@ class RDDLEnv(gym.Env):
         action_space = Dict()
         for act in self.defaultAction:
             act_range = self.actionsranges[act]
-            if act_range in self.model.enum_types:
+            if act_range in self.model.enums:
                 action_space[act] = Discrete(len(self.model.objects[act_range]))            
             elif act_range == 'real':
                 action_space[act] = Box(low=bounds[act][0],
@@ -102,7 +102,7 @@ class RDDLEnv(gym.Env):
         state_space = Dict()
         for state in search_dict:
             state_range = ranges[state]
-            if state_range in self.model.enum_types:
+            if state_range in self.model.enums:
                 state_space[state] = Discrete(len(self.model.objects[state_range]))          
             elif state_range == 'real':
                 state_space[state] = Box(low=bounds[state][0],

--- a/pyRDDLGym/Core/Grounder/RDDLGrounder.py
+++ b/pyRDDLGym/Core/Grounder/RDDLGrounder.py
@@ -66,8 +66,7 @@ class RDDLGrounder(Grounder):
         self.invariants = []
         
         self.index_of_object = {}
-        self.enum_types = set()
-        self.enum_literals = set()
+        self.enums = set()
         
         self.param_types = {}
         self.variable_types = {}
@@ -122,8 +121,7 @@ class RDDLGrounder(Grounder):
         model.variable_ranges = self.variable_ranges
         
         model.index_of_object = self.index_of_object
-        model.enum_types = self.enum_types
-        model.enum_literals = self.enum_literals        
+        model.enums = self.enums   
         model.grounded_names = self.grounded_names
         
         return model
@@ -159,8 +157,7 @@ class RDDLGrounder(Grounder):
                 for obj in obj_type[1]:
                     self.objects_rev[obj] = obj_type[0]
         self.index_of_object = {}
-        self.enum_types = set()
-        self.enum_literals = set()
+        self.enums = set()
 
     def _ground_objects(self, args):
         objects_by_type = []
@@ -176,8 +173,7 @@ class RDDLGrounder(Grounder):
         objects = RDDLGroundedModel.OBJECT_SEP.join(variation)
         return base_name + RDDLGroundedModel.FLUENT_SEP + objects
         
-    def _generate_grounded_names(self, base_name,
-                                 variation_list,
+    def _generate_grounded_names(self, base_name, variation_list,
                                  return_grounding_param_dict=False):
         PRIME = RDDLGroundedModel.NEXT_STATE_SYM
         all_grounded_names = []

--- a/pyRDDLGym/Core/Jax/JaxRDDLSimulator.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLSimulator.py
@@ -45,12 +45,12 @@ class JaxRDDLSimulator(RDDLSimulator):
         super(JaxRDDLSimulator, self).__init__(rddl, logger=logger)
     
     def _compile(self):
+        rddl = self.rddl
         
         # compilation
         if self.logger is not None:
             self.logger.clear()
-        compiled = JaxRDDLCompiler(self.rddl, logger=self.logger, 
-                                   **self.compiler_args)
+        compiled = JaxRDDLCompiler(rddl, logger=self.logger, **self.compiler_args)
         compiled.compile(log_jax_expr=True)
         self.init_values = compiled.init_values
         self.levels = compiled.levels
@@ -67,7 +67,7 @@ class JaxRDDLSimulator(RDDLSimulator):
         for cpfs in self.levels.values():
             for cpf in cpfs:
                 expr = jax_cpfs[cpf]
-                prange = self.rddl.variable_ranges[cpf]
+                prange = rddl.variable_ranges[cpf]
                 dtype = JaxRDDLCompiler.JAX_TYPES.get(prange, JaxRDDLCompiler.INT)
                 self.cpfs.append((cpf, expr, dtype))
         
@@ -76,8 +76,8 @@ class JaxRDDLSimulator(RDDLSimulator):
         self.state = None 
         self.noop_actions = {var: values 
                              for (var, values) in self.init_values.items() 
-                             if self.rddl.variable_types[var] == 'action-fluent'}
-        self._pomdp = bool(self.rddl.observ)
+                             if rddl.variable_types[var] == 'action-fluent'}
+        self._pomdp = bool(rddl.observ)
         
     def handle_error_code(self, error, msg) -> None:
         if self.raise_error:
@@ -129,6 +129,7 @@ class JaxRDDLSimulator(RDDLSimulator):
         
         :param actions: a dict mapping current action fluents to their values
         '''
+        rddl = self.rddl
         actions = self._process_actions(actions)
         subs = self.subs
         subs.update(actions)
@@ -142,7 +143,6 @@ class JaxRDDLSimulator(RDDLSimulator):
         reward = self.sample_reward()
         
         # update state
-        rddl = self.rddl
         self.state = {}
         for (state, next_state) in rddl.next_state.items():
             subs[state] = subs[next_state]


### PR DESCRIPTION
- the separation between object and "enum" is now obsolete
- the framework has been reworked to have one storage for all objects regardless of definition origin, but enums set is there to test origin
- simulator performance should be improved with this version, since object checks are moved out of the simulator
- better and more type checks for instance blocks