### PR TITLE
Fixing equations for temp and acc in Cartpole CPF

### DIFF
--- a/pyRDDLGym/Domains/Examples/CartPole/Continuous/domain.rddl
+++ b/pyRDDLGym/Domains/Examples/CartPole/Continuous/domain.rddl
@@ -47,12 +47,12 @@ domain cart_pole_continuous {
     cpfs {
 		
 		// compute the pole angular acceleration
-		temp = (force + POLE-LEN * pow[ang-vel, 2] * sin[ang-pos]) / (CART-MASS + POLE-MASS);
+		temp = (force + POLE-LEN * POLE-MASS * pow[ang-vel, 2] * sin[ang-pos]) / (CART-MASS + POLE-MASS);
 		ang-acc = (GRAVITY * sin[ang-pos] - cos[ang-pos] * temp) / (
             POLE-LEN * ((4.0 / 3.0) - (POLE-MASS * pow[cos[ang-pos], 2] / (CART-MASS + POLE-MASS))));
 		
 		// compute the cart acceleration
-		acc = temp - (POLE-LEN * ang-acc * cos[ang-pos] / (CART-MASS + POLE-MASS));
+		acc = temp - (POLE-LEN * POLE-MASS * ang-acc * cos[ang-pos] / (CART-MASS + POLE-MASS));
 
 		// Euler integration formula
 		pos' = pos + TIME-STEP * vel;

--- a/pyRDDLGym/Domains/Examples/CartPole/Discrete/domain.rddl
+++ b/pyRDDLGym/Domains/Examples/CartPole/Discrete/domain.rddl
@@ -52,12 +52,12 @@ domain cart_pole_discrete {
 				 else -FORCE-MAG;
 		
 		// compute the pole angular acceleration
-		temp = (force + POLE-LEN * pow[ang-vel, 2] * sin[ang-pos]) / (CART-MASS + POLE-MASS);
+		temp = (force + POLE-LEN * POLE-MASS * pow[ang-vel, 2] * sin[ang-pos]) / (CART-MASS + POLE-MASS);
 		ang-acc = (GRAVITY * sin[ang-pos] - cos[ang-pos] * temp) / (
             POLE-LEN * ((4.0 / 3.0) - (POLE-MASS * pow[cos[ang-pos], 2] / (CART-MASS + POLE-MASS))));
 		
 		// compute the cart acceleration
-		acc = temp - (POLE-LEN * ang-acc * cos[ang-pos] / (CART-MASS + POLE-MASS));
+		acc = temp - (POLE-LEN * POLE-MASS * ang-acc * cos[ang-pos] / (CART-MASS + POLE-MASS));
 
 		// Euler integration formula
 		pos' = pos + TIME-STEP * vel;


### PR DESCRIPTION
The equations for temp and acc in Cartpole use `polemass_length` which is the product of `masspole` and `length`. In the RDDL file, the equations were just using `POLE-LEN`. Modified it to now use `POLE-LEN * POLE-MASS`
![image](https://user-images.githubusercontent.com/11463842/218232276-f66855d1-2b7c-4821-834f-1f20c3ed7f6d.png)
