### PR TITLE
Jax per node parameters

### DIFF
--- a/pyRDDLGym/Core/Compiler/RDDLObjectsTracer.py
+++ b/pyRDDLGym/Core/Compiler/RDDLObjectsTracer.py
@@ -22,6 +22,7 @@ class RDDLTracedObjects:
         self._cached_objects_in_scope = []
         self._cached_enum_type = []
         self._cached_sim_info = []
+        self._expr_from_id = {}
         
     def _append(self, expr, objects, enum_type, info) -> None:
         expr.id = self._current_id
@@ -30,6 +31,7 @@ class RDDLTracedObjects:
         self._cached_objects_in_scope.append(objects)
         self._cached_enum_type.append(enum_type)
         self._cached_sim_info.append(info)
+        self._expr_from_id[expr.id] = expr
         
     def cached_objects_in_scope(self, expr: Expression):
         '''Returns the free variables/parameters in the scope of expression.'''
@@ -42,6 +44,11 @@ class RDDLTracedObjects:
     def cached_sim_info(self, expr: Expression) -> object:
         '''Returns compiled info that is specific to the expression.'''
         return self._cached_sim_info[expr.id]
+    
+    def lookup(self, identifier: int) -> Expression:
+        '''Returns the expression with given identifier, or None if does not 
+        exist.'''
+        return self._expr_from_id.get(identifier, None)
 
 
 def py_enum(**enums):
@@ -721,7 +728,7 @@ class RDDLObjectsTracer:
         # no duplicate cases are allowed
         if len(case_dict) != len(cases):
             raise RDDLInvalidNumberOfArgumentsError(
-                f'Duplicated literal or default case(s).\n' +
+                f'Duplicated literal or default case(s).\n' + 
                 print_stack_trace(expr))
         
         # no default cases are allowed

--- a/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
@@ -47,92 +47,86 @@ class JaxRDDLCompilerWithGrad(JaxRDDLCompiler):
         warnings.warn(f'Initial values of pvariables will be cast to real.',
                       stacklevel=2)   
         for (var, values) in self.init_values.items():
-            self.init_values[var] = np.asarray(values, dtype=RDDLValueInitializer.REAL) 
+            self.init_values[var] = np.asarray(
+                values, dtype=RDDLValueInitializer.REAL) 
         
         # overwrite basic operations with fuzzy ones
         self.RELATIONAL_OPS = {
-            '>=': logic.greaterEqual,
-            '<=': logic.lessEqual,
-            '<': logic.less,
-            '>': logic.greater,
-            '==': logic.equal,
-            '~=': logic.notEqual
+            '>=': logic.greaterEqual(),
+            '<=': logic.lessEqual(),
+            '<': logic.less(),
+            '>': logic.greater(),
+            '==': logic.equal(),
+            '~=': logic.notEqual()
         }
-        self.LOGICAL_NOT = logic.Not  
+        self.LOGICAL_NOT = logic.Not()
         self.LOGICAL_OPS = {
-            '^': logic.And,
-            '&': logic.And,
-            '|': logic.Or,
-            '~': logic.xor,
-            '=>': logic.implies,
-            '<=>': logic.equiv
+            '^': logic.And(),
+            '&': logic.And(),
+            '|': logic.Or(),
+            '~': logic.xor(),
+            '=>': logic.implies(),
+            '<=>': logic.equiv()
         }
-        self.AGGREGATION_OPS = {
-            'sum': jnp.sum,
-            'avg': jnp.mean,
-            'prod': jnp.prod,
-            'minimum': jnp.min,
-            'maximum': jnp.max,
-            'forall': logic.forall,
-            'exists': logic.exists,
-            'argmin': logic.argmin,
-            'argmax': logic.argmax
-        }
-        self.KNOWN_UNARY['sgn'] = logic.signum   
-        self.KNOWN_UNARY['floor'] = logic.floor   
-        self.KNOWN_UNARY['ceil'] = logic.ceil   
-        self.KNOWN_UNARY['round'] = logic.round
-        self.KNOWN_UNARY['sqrt'] = logic.sqrt
-        self.KNOWN_BINARY['div'] = logic.floorDiv
-        self.KNOWN_BINARY['mod'] = logic.mod
+        self.AGGREGATION_OPS['forall'] = logic.forall()
+        self.AGGREGATION_OPS['exists'] = logic.exists()
+        self.AGGREGATION_OPS['argmin'] = logic.argmin()
+        self.AGGREGATION_OPS['argmax'] = logic.argmax()
+        self.KNOWN_UNARY['sgn'] = logic.signum()
+        self.KNOWN_UNARY['floor'] = logic.floor()   
+        self.KNOWN_UNARY['ceil'] = logic.ceil()   
+        self.KNOWN_UNARY['round'] = logic.round()
+        self.KNOWN_UNARY['sqrt'] = logic.sqrt()
+        self.KNOWN_BINARY['div'] = logic.floorDiv()
+        self.KNOWN_BINARY['mod'] = logic.mod()
     
     def _jax_stop_grad(self, jax_expr):
         
-        def _jax_wrapped_stop_grad(x, key):
-            sample, key, error = jax_expr(x, key)
+        def _jax_wrapped_stop_grad(x, params, key):
+            sample, key, error = jax_expr(x, params, key)
             sample = jax.lax.stop_gradient(sample)
             return sample, key, error
         
         return _jax_wrapped_stop_grad
         
-    def _compile_cpfs(self):
+    def _compile_cpfs(self, info):
         warnings.warn('CPFs outputs will be cast to real.', stacklevel=2)      
         jax_cpfs = {}
         for (_, cpfs) in self.levels.items():
             for cpf in cpfs:
                 _, expr = self.rddl.cpfs[cpf]
-                jax_cpfs[cpf] = self._jax(expr, dtype=JaxRDDLCompiler.REAL)
+                jax_cpfs[cpf] = self._jax(expr, info, dtype=JaxRDDLCompiler.REAL)
                 if cpf in self.cpfs_without_grad:
                     warnings.warn(f'CPF <{cpf}> stops gradient.', stacklevel=2)      
                     jax_cpfs[cpf] = self._jax_stop_grad(jax_cpfs[cpf])
         return jax_cpfs
     
     def _jax_if_helper(self):
-        return self.logic.If
+        return self.logic.If()
     
     def _jax_switch_helper(self):
-        return self.logic.Switch
+        return self.logic.Switch()
         
-    def _jax_kron(self, expr):
+    def _jax_kron(self, expr, info):
         warnings.warn('KronDelta will be ignored.', stacklevel=2)                       
         arg, = expr.args
-        arg = self._jax(arg)
+        arg = self._jax(arg, info)
         return arg
     
     def _jax_bernoulli_helper(self):
-        return self.logic.bernoulli
+        return self.logic.bernoulli()
     
     def _jax_discrete_helper(self):
-        discrete = self.logic.discrete
+        jax_discrete, jax_param = self.logic.discrete()
 
-        def _jax_discrete_calc_approx(key, prob):
-            sample = discrete(key, prob)
+        def _jax_wrapped_discrete_calc_approx(key, prob, params):
+            sample = jax_discrete(key, prob, params)
             out_of_bounds = jnp.logical_not(jnp.logical_and(
                 jnp.all(prob >= 0),
                 jnp.allclose(jnp.sum(prob, axis=-1), 1.0)))
             return sample, out_of_bounds
         
-        return _jax_discrete_calc_approx
+        return _jax_wrapped_discrete_calc_approx, jax_param
 
 
 class JaxPlan:
@@ -353,7 +347,7 @@ class JaxRDDLBackpropPlanner:
                  rollout_horizon: int=None,
                  action_bounds: Dict[str, Tuple[float, float]]={},
                  optimizer: optax.GradientTransformation=optax.rmsprop(0.1),
-                 clip_grad: float=1000.,
+                 clip_grad: float=9999.,
                  logic: FuzzyLogic=FuzzyLogic(),
                  use_symlog_reward: bool=False,
                  utility=jnp.mean,
@@ -418,6 +412,8 @@ class JaxRDDLBackpropPlanner:
             cpfs_without_grad=self.cpfs_without_grad)
         self.compiled.compile()
         
+        print(self.compiled.model_params)
+        
         # Jax compilation of the exact RDDL for testing
         self.test_compiled = JaxRDDLCompiler(rddl=rddl)
         self.test_compiled.compile()
@@ -480,8 +476,8 @@ class JaxRDDLBackpropPlanner:
             return rewards
         
         # the loss is the average cumulative reward across all roll-outs
-        def _jax_wrapped_plan_loss(key, params, subs):
-            log = rollouts(key, params, subs)
+        def _jax_wrapped_plan_loss(key, policy_params, subs, model_params):
+            log = rollouts(key, policy_params, subs, model_params)
             rewards = log['reward']
             rewards = _jax_wrapped_scale_reward(rewards)
             returns = jnp.sum(rewards, axis=1)
@@ -496,14 +492,17 @@ class JaxRDDLBackpropPlanner:
         # calculate the plan gradient w.r.t. return loss and update optimizer
         # optionally does gradient normalization
         # also perform a projection step to satisfy constraints on actions
-        def _jax_wrapped_plan_update(key, params, subs, opt_state):
-            grad, log = jax.grad(loss, argnums=1, has_aux=True)(key, params, subs)
+        def _jax_wrapped_plan_update(
+                key, policy_params, subs, model_params, opt_state):
+            grad, log = jax.grad(
+                loss, argnums=1, has_aux=True)(
+                    key, policy_params, subs, model_params)
             
             log['grad'] = grad
             updates, opt_state = optimizer.update(grad, opt_state)
-            params = optax.apply_updates(params, updates)
-            params = projection(params)
-            return params, opt_state, log
+            policy_params = optax.apply_updates(policy_params, updates)
+            policy_params = projection(policy_params)
+            return policy_params, opt_state, log
         
         return _jax_wrapped_plan_update
             
@@ -548,26 +547,33 @@ class JaxRDDLBackpropPlanner:
             subs = self.test_compiled.init_values
         train_subs, test_subs = self._batched_init_subs(subs)
         
+        # initialize, model parameters
+        model_params = self.compiled.model_params
+        model_params_test = self.test_compiled.model_params
+        
         # initialize policy parameters
         if guess is None:
             key, subkey = random.split(key)
-            params, opt_state = self.initialize(subkey, train_subs)
+            policy_params, opt_state = self.initialize(subkey, train_subs)
         else:
-            params = guess
-            opt_state = self.optimizer.init(params)
-        best_params, best_loss = params, jnp.inf
+            policy_params = guess
+            opt_state = self.optimizer.init(policy_params)
+        best_params, best_loss = policy_params, jnp.inf
         
         for it in range(epochs):
             
             # update the parameters of the plan
             key, subkey1, subkey2, subkey3 = random.split(key, num=4)
-            params, opt_state, train_log = self.update(subkey1, params, train_subs, opt_state)            
-            train_loss, _ = self.train_loss(subkey2, params, train_subs)            
-            test_loss, log = self.test_loss(subkey3, params, test_subs)
+            policy_params, opt_state, train_log = self.update(
+                subkey1, policy_params, train_subs, model_params, opt_state)
+            train_loss, _ = self.train_loss(
+                subkey2, policy_params, train_subs, model_params)
+            test_loss, log = self.test_loss(
+                subkey3, policy_params, test_subs, model_params_test)
             
             # record the best plan so far
             if test_loss < best_loss:
-                best_params, best_loss = params, test_loss
+                best_params, best_loss = policy_params, test_loss
             
             # periodically return a callback
             if it % step == 0 or it == epochs - 1:
@@ -576,7 +582,7 @@ class JaxRDDLBackpropPlanner:
                     'train_return':-train_loss,
                     'test_return':-test_loss,
                     'best_return':-best_loss,
-                    'params': params,
+                    'params': policy_params,
                     'best_params': best_params,
                     'grad': train_log['grad'],
                     **log
@@ -682,14 +688,17 @@ class JaxRDDLModelError:
                 test_subs[next_state] = test_subs[state]
             return train_subs, test_subs
         
-        def _jax_wrapped_simulate_particles(key, params, subs):
+        def _jax_wrapped_simulate_particles(
+                key, policy_params, subs, model_params, model_params_test):
             
             # train and test subs differ only in data type
             train_subs, test_subs = _jax_wrapped_batched_subs(subs)
             
             # generate rollouts from train and test model for the same inputs
-            train_log = train_rollouts(key, params, train_subs)
-            test_log = test_rollouts(key, params, test_subs)
+            train_log = train_rollouts(
+                key, policy_params, train_subs, model_params)
+            test_log = test_rollouts(
+                key, policy_params, test_subs, model_params_test)
             
             # extract variables and reward
             train_pvars = train_log['pvar']
@@ -711,13 +720,19 @@ class JaxRDDLModelError:
         
         self.simulation = jax.jit(_jax_wrapped_simulate_particles)
     
-    def summarize(self, key: random.PRNGKey, params: Dict, subs: Dict=None,
-                  filename: str='summary.pdf', figsize=(6, 3)):
+    def summarize(self, key: random.PRNGKey,
+                  params: Dict,
+                  subs: Dict=None,
+                  filename: str='summary.pdf',
+                  figsize: Tuple[int, int]=(6, 3)):
         
         # get train and test particles
         if subs is None:
             subs = self.test_compiled.init_values
-        train_fluents, test_fluents = self.simulation(key, params, subs)
+        train_fluents, test_fluents = self.simulation(
+            key, params, subs,
+            self.train_compiled.model_params,
+            self.test_compiled.model_params)
         
         # figure out # of plots required to plot each fluent component separately
         sizes = {name: np.prod(value.shape[2:], dtype=int)
@@ -751,9 +766,9 @@ class JaxRDDLModelError:
                 
                 # show mean
                 xs = np.arange(train_mean.shape[0])
-                axs[iy, ix].plot(xs, train_mean[:, j], label='approx mean', 
+                axs[iy, ix].plot(xs, train_mean[:, j], label='approx mean',
                                  color='blue')
-                axs[iy, ix].plot(xs, test_mean[:, j], label='true mean', 
+                axs[iy, ix].plot(xs, test_mean[:, j], label='true mean',
                                  linestyle='dashed', color='black')
                 
                 # show two standard deviations spread

--- a/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
@@ -412,8 +412,6 @@ class JaxRDDLBackpropPlanner:
             cpfs_without_grad=self.cpfs_without_grad)
         self.compiled.compile()
         
-        print(self.compiled.model_params)
-        
         # Jax compilation of the exact RDDL for testing
         self.test_compiled = JaxRDDLCompiler(rddl=rddl)
         self.test_compiled.compile()

--- a/pyRDDLGym/Core/Jax/JaxRDDLCompiler.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLCompiler.py
@@ -188,7 +188,8 @@ class JaxRDDLCompiler:
         return self._jax(self.rddl.reward, info, dtype=JaxRDDLCompiler.REAL)
     
     def compile_rollouts(self, policy: Callable,
-                         n_steps: int, n_batch: int,
+                         n_steps: int, 
+                         n_batch: int,
                          check_constraints: bool=False):
         '''Compiles the current RDDL into a wrapped function that samples multiple
         rollouts (state trajectories) in batched form for the given policy. The

--- a/pyRDDLGym/Core/Jax/JaxRDDLCompiler.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLCompiler.py
@@ -59,70 +59,71 @@ class JaxRDDLCompiler:
         tracer = RDDLObjectsTracer(rddl, logger=self.logger)
         self.traced = tracer.trace()
         
-        # basic operations        
+        # basic operations
+        self.NEGATIVE = lambda x, param: jnp.negative(x)  
         self.ARITHMETIC_OPS = {
-            '+': jnp.add,
-            '-': jnp.subtract,
-            '*': jnp.multiply,
-            '/': jnp.divide
+            '+': lambda x, y, param: jnp.add(x, y),
+            '-': lambda x, y, param: jnp.subtract(x, y),
+            '*': lambda x, y, param: jnp.multiply(x, y),
+            '/': lambda x, y, param: jnp.divide(x, y)
         }    
         self.RELATIONAL_OPS = {
-            '>=': jnp.greater_equal,
-            '<=': jnp.less_equal,
-            '<': jnp.less,
-            '>': jnp.greater,
-            '==': jnp.equal,
-            '~=': jnp.not_equal
+            '>=': lambda x, y, param: jnp.greater_equal(x, y),
+            '<=': lambda x, y, param: jnp.less_equal(x, y),
+            '<': lambda x, y, param: jnp.less(x, y),
+            '>': lambda x, y, param: jnp.greater(x, y),
+            '==': lambda x, y, param: jnp.equal(x, y),
+            '~=': lambda x, y, param: jnp.not_equal(x, y)
         }
-        self.LOGICAL_NOT = jnp.logical_not
+        self.LOGICAL_NOT = lambda x, param: jnp.logical_not(x)
         self.LOGICAL_OPS = {
-            '^': jnp.logical_and,
-            '&': jnp.logical_and,
-            '|': jnp.logical_or,
-            '~': jnp.logical_xor,
-            '=>': lambda e1, e2: jnp.logical_or(jnp.logical_not(e1), e2),
-            '<=>': jnp.equal
+            '^': lambda x, y, param: jnp.logical_and(x, y),
+            '&': lambda x, y, param: jnp.logical_and(x, y),
+            '|': lambda x, y, param: jnp.logical_or(x, y),
+            '~': lambda x, y, param: jnp.logical_xor(x, y),
+            '=>': lambda x, y, param: jnp.logical_or(jnp.logical_not(x), y),
+            '<=>': lambda x, y, param: jnp.equal(x, y)
         }
         self.AGGREGATION_OPS = {
-            'sum': jnp.sum,
-            'avg': jnp.mean,
-            'prod': jnp.prod,
-            'minimum': jnp.min,
-            'maximum': jnp.max,
-            'forall': jnp.all,
-            'exists': jnp.any,
-            'argmin': jnp.argmin,
-            'argmax': jnp.argmax
+            'sum': lambda x, axis, param: jnp.sum(x, axis=axis),
+            'avg': lambda x, axis, param: jnp.mean(x, axis=axis),
+            'prod': lambda x, axis, param: jnp.prod(x, axis=axis),
+            'minimum': lambda x, axis, param: jnp.min(x, axis=axis),
+            'maximum': lambda x, axis, param: jnp.max(x, axis=axis),
+            'forall': lambda x, axis, param: jnp.all(x, axis=axis),
+            'exists': lambda x, axis, param: jnp.any(x, axis=axis),
+            'argmin': lambda x, axis, param: jnp.argmin(x, axis=axis),
+            'argmax': lambda x, axis, param: jnp.argmax(x, axis=axis)
         }
         self.KNOWN_UNARY = {        
-            'abs': jnp.abs,
-            'sgn': jnp.sign,
-            'round': jnp.round,
-            'floor': jnp.floor,
-            'ceil': jnp.ceil,
-            'cos': jnp.cos,
-            'sin': jnp.sin,
-            'tan': jnp.tan,
-            'acos': jnp.arccos,
-            'asin': jnp.arcsin,
-            'atan': jnp.arctan,
-            'cosh': jnp.cosh,
-            'sinh': jnp.sinh,
-            'tanh': jnp.tanh,
-            'exp': jnp.exp,
-            'ln': jnp.log,
-            'sqrt': jnp.sqrt,
-            'lngamma': scipy.special.gammaln,
-            'gamma': lambda x: jnp.exp(scipy.special.gammaln(x))
+            'abs': lambda x, param: jnp.abs(x),
+            'sgn': lambda x, param: jnp.sign(x),
+            'round': lambda x, param: jnp.round(x),
+            'floor': lambda x, param: jnp.floor(x),
+            'ceil': lambda x, param: jnp.ceil(x),
+            'cos': lambda x, param: jnp.cos(x),
+            'sin': lambda x, param: jnp.sin(x),
+            'tan': lambda x, param: jnp.tan(x),
+            'acos': lambda x, param: jnp.arccos(x),
+            'asin': lambda x, param: jnp.arcsin(x),
+            'atan': lambda x, param: jnp.arctan(x),
+            'cosh': lambda x, param: jnp.cosh(x),
+            'sinh': lambda x, param: jnp.sinh(x),
+            'tanh': lambda x, param: jnp.tanh(x),
+            'exp': lambda x, param: jnp.exp(x),
+            'ln': lambda x, param: jnp.log(x),
+            'sqrt': lambda x, param: jnp.sqrt(x),
+            'lngamma': lambda x, param: scipy.special.gammaln(x),
+            'gamma': lambda x, param: jnp.exp(scipy.special.gammaln(x))
         }        
         self.KNOWN_BINARY = {
-            'div': jnp.floor_divide,
-            'mod': jnp.mod,
-            'min': jnp.minimum,
-            'max': jnp.maximum,
-            'pow': jnp.power,
-            'log': lambda x, y: jnp.log(x) / jnp.log(y),
-            'hypot': jnp.hypot
+            'div': lambda x, y, param: jnp.floor_divide(x, y),
+            'mod': lambda x, y, param: jnp.mod(x, y),
+            'min': lambda x, y, param: jnp.minimum(x, y),
+            'max': lambda x, y, param: jnp.maximum(x, y),
+            'pow': lambda x, y, param: jnp.power(x, y),
+            'log': lambda x, y, param: jnp.log(x) / jnp.log(y),
+            'hypot': lambda x, y, param: jnp.hypot(x, y)
         }
         
     # ===========================================================================
@@ -135,11 +136,13 @@ class JaxRDDLCompiler:
         :param log_jax_expr: whether to pretty-print the compiled Jax functions
         to the log file
         '''
-        self.invariants = self._compile_constraints(self.rddl.invariants)
-        self.preconditions = self._compile_constraints(self.rddl.preconditions)
-        self.termination = self._compile_constraints(self.rddl.terminals)
-        self.cpfs = self._compile_cpfs()
-        self.reward = self._compile_reward()
+        info = {}
+        self.invariants = self._compile_constraints(self.rddl.invariants, info)
+        self.preconditions = self._compile_constraints(self.rddl.preconditions, info)
+        self.termination = self._compile_constraints(self.rddl.terminals, info)
+        self.cpfs = self._compile_cpfs(info)
+        self.reward = self._compile_reward(info)
+        self.model_params = info
         
         if log_jax_expr and self.logger is not None:
             printed = self.print_jax()
@@ -149,35 +152,40 @@ class JaxRDDLCompiler:
             printed_invariants = '\n\n'.join(v for v in printed['invariants'])
             printed_preconds = '\n\n'.join(v for v in printed['preconditions'])
             printed_terminals = '\n\n'.join(v for v in printed['terminations'])
-            message = (f'compiled JAX CPFs:\n\n'
-                       f'{printed_cpfs}\n\n'
-                       f'compiled JAX reward:\n\n'
-                       f'{printed_reward}\n\n'
-                       f'compiled JAX invariants:\n\n'
-                       f'{printed_invariants}\n\n'
-                       f'compiled JAX preconditions:\n\n'
-                       f'{printed_preconds}\n\n'
-                       f'compiled JAX terminations:\n\n'
-                       f'{printed_terminals}\n')
+            printed_params = '\n'.join(f'{k}: {v}' for (k, v) in info.items())
+            message = (
+                f'compiled JAX CPFs:\n\n'
+                f'{printed_cpfs}\n\n'
+                f'compiled JAX reward:\n\n'
+                f'{printed_reward}\n\n'
+                f'compiled JAX invariants:\n\n'
+                f'{printed_invariants}\n\n'
+                f'compiled JAX preconditions:\n\n'
+                f'{printed_preconds}\n\n'
+                f'compiled JAX terminations:\n\n'
+                f'{printed_terminals}\n'
+                f'model parameters:\n'
+                f'{printed_params}\n'
+            )
             self.logger.log(message)
     
-    def _compile_constraints(self, constraints):
-        return [self._jax(expr, dtype=bool) for expr in constraints]
+    def _compile_constraints(self, constraints, info):
+        return [self._jax(expr, info, dtype=bool) for expr in constraints]
         
-    def _compile_cpfs(self):
+    def _compile_cpfs(self, info):
         jax_cpfs = {}
         for cpfs in self.levels.values():
             for cpf in cpfs:
                 _, expr = self.rddl.cpfs[cpf]
                 prange = self.rddl.variable_ranges[cpf]
                 dtype = JaxRDDLCompiler.JAX_TYPES.get(prange, JaxRDDLCompiler.INT)
-                jax_cpfs[cpf] = self._jax(expr, dtype=dtype)
+                jax_cpfs[cpf] = self._jax(expr, info, dtype=dtype)
         return jax_cpfs
     
-    def _compile_reward(self):
-        return self._jax(self.rddl.reward, dtype=JaxRDDLCompiler.REAL)
+    def _compile_reward(self, info):
+        return self._jax(self.rddl.reward, info, dtype=JaxRDDLCompiler.REAL)
     
-    def compile_rollouts(self, policy: Callable, 
+    def compile_rollouts(self, policy: Callable,
                          n_steps: int, n_batch: int,
                          check_constraints: bool=False):
         '''Compiles the current RDDL into a wrapped function that samples multiple
@@ -201,7 +209,7 @@ class JaxRDDLCompiler:
             self.preconditions, self.invariants, self.termination
         
         # do a single step update from the RDDL model
-        def _jax_wrapped_single_step(key, params, step, subs):
+        def _jax_wrapped_single_step(key, policy_params, step, subs, model_params):
             errors = NORMAL
             
             # compute action
@@ -209,24 +217,24 @@ class JaxRDDLCompiler:
             states = {var: values 
                       for (var, values) in subs.items()
                       if rddl.variable_types[var] == 'state-fluent'}
-            actions = policy(subkey, params, step, states)
+            actions = policy(subkey, policy_params, step, states)
             subs.update(actions)
             
             # check action preconditions
             precond_check = True
             if check_constraints:
                 for precond in preconds:
-                    sample, key, err = precond(subs, key)
+                    sample, key, err = precond(subs, model_params, key)
                     precond_check = jnp.logical_and(precond_check, sample)
                     errors |= err
             
             # calculate CPFs in topological order
             for (name, cpf) in cpfs.items():
-                subs[name], key, err = cpf(subs, key)
+                subs[name], key, err = cpf(subs, model_params, key)
                 errors |= err                
                 
             # calculate the immediate reward
-            reward, key, err = reward_fn(subs, key)
+            reward, key, err = reward_fn(subs, model_params, key)
             errors |= err
             
             # set the next state to the current state
@@ -237,7 +245,7 @@ class JaxRDDLCompiler:
             invariant_check = True
             if check_constraints:
                 for invariant in invariants:
-                    sample, key, err = invariant(subs, key)
+                    sample, key, err = invariant(subs, model_params, key)
                     invariant_check = jnp.logical_and(invariant_check, sample)
                     errors |= err
             
@@ -245,7 +253,7 @@ class JaxRDDLCompiler:
             terminated_check = False
             if check_constraints:
                 for terminal in terminals:
-                    sample, key, err = terminal(subs, key)
+                    sample, key, err = terminal(subs, model_params, key)
                     terminated_check = jnp.logical_or(terminated_check, sample)
                     errors |= err
             
@@ -262,18 +270,20 @@ class JaxRDDLCompiler:
         
         # do a batched step update from the RDDL model
         def _jax_wrapped_batched_step(carry, step):
-            key, params, subs = carry  
+            key, policy_params, subs, model_params = carry  
             key, *subkeys = random.split(key, num=1 + n_batch)
             batched_step = jax.vmap(
-                _jax_wrapped_single_step, in_axes=(0, None, None, 0)
+                _jax_wrapped_single_step,
+                in_axes=(0, None, None, 0, None)
             ) 
-            log, subs = batched_step(jnp.asarray(subkeys), params, step, subs)            
-            carry = (key, params, subs)
+            keys = jnp.asarray(subkeys)
+            log, subs = batched_step(keys, policy_params, step, subs, model_params)            
+            carry = (key, policy_params, subs, model_params)
             return carry, log            
             
         # do a batched roll-out from the RDDL model
-        def _jax_wrapped_batched_rollout(key, params, subs):
-            start = (key, params, subs)
+        def _jax_wrapped_batched_rollout(key, policy_params, subs, model_params):
+            start = (key, policy_params, subs, model_params)
             steps = jnp.arange(n_steps)
             _, log = jax.lax.scan(_jax_wrapped_batched_step, start, steps)
             log = jax.tree_map(partial(jnp.swapaxes, axis1=0, axis2=1), log)
@@ -285,21 +295,22 @@ class JaxRDDLCompiler:
     # error checks
     # ===========================================================================
     
-    def print_jax(self) -> Dict:
+    def print_jax(self) -> Dict[str, object]:
         '''Returns a dictionary containing the string representations of all 
         Jax compiled expressions from the RDDL file.
         '''
         subs = self.init_values
+        params = self.model_params
         key = jax.random.PRNGKey(42)
         printed = {}
-        printed['cpfs'] = {name: str(jax.make_jaxpr(expr)(subs, key))
+        printed['cpfs'] = {name: str(jax.make_jaxpr(expr)(subs, params, key))
                            for (name, expr) in self.cpfs.items()}
-        printed['reward'] = str(jax.make_jaxpr(self.reward)(subs, key))
-        printed['invariants'] = [str(jax.make_jaxpr(expr)(subs, key))
+        printed['reward'] = str(jax.make_jaxpr(self.reward)(subs, params, key))
+        printed['invariants'] = [str(jax.make_jaxpr(expr)(subs, params, key))
                                  for expr in self.invariants]
-        printed['preconditions'] = [str(jax.make_jaxpr(expr)(subs, key))
+        printed['preconditions'] = [str(jax.make_jaxpr(expr)(subs, params, key))
                                     for expr in self.preconditions]
-        printed['terminations'] = [str(jax.make_jaxpr(expr)(subs, key))
+        printed['terminations'] = [str(jax.make_jaxpr(expr)(subs, params, key))
                                    for expr in self.termination]
         return printed
         
@@ -310,7 +321,8 @@ class JaxRDDLCompiler:
             valid_op_str = ','.join(valid_ops.keys())
             raise RDDLNotImplementedError(
                 f'{etype} operator {op} is not supported: '
-                f'must be in {valid_op_str}.\n' + print_stack_trace(expr))
+                f'must be in {valid_op_str}.\n' + 
+                print_stack_trace(expr))
     
     @staticmethod
     def _check_num_args(expr, required_args):
@@ -319,7 +331,8 @@ class JaxRDDLCompiler:
             etype, op = expr.etype
             raise RDDLInvalidNumberOfArgumentsError(
                 f'{etype} operator {op} requires {required_args} arguments, '
-                f'got {actual_args}.\n' + print_stack_trace(expr))
+                f'got {actual_args}.\n' + 
+                print_stack_trace(expr))
         
     ERROR_CODES = {
         'NORMAL': 0,
@@ -400,30 +413,30 @@ class JaxRDDLCompiler:
     # expression compilation
     # ===========================================================================
     
-    def _jax(self, expr, dtype=None):
+    def _jax(self, expr, info, dtype=None):
         etype, _ = expr.etype
         if etype == 'constant':
-            jax_expr = self._jax_constant(expr)
+            jax_expr = self._jax_constant(expr, info)
         elif etype == 'pvar':
-            jax_expr = self._jax_pvar(expr)
+            jax_expr = self._jax_pvar(expr, info)
         elif etype == 'arithmetic':
-            jax_expr = self._jax_arithmetic(expr)
+            jax_expr = self._jax_arithmetic(expr, info)
         elif etype == 'relational':
-            jax_expr = self._jax_relational(expr)
+            jax_expr = self._jax_relational(expr, info)
         elif etype == 'boolean':
-            jax_expr = self._jax_logical(expr)
+            jax_expr = self._jax_logical(expr, info)
         elif etype == 'aggregation':
-            jax_expr = self._jax_aggregation(expr)
+            jax_expr = self._jax_aggregation(expr, info)
         elif etype == 'func':
-            jax_expr = self._jax_functional(expr)
+            jax_expr = self._jax_functional(expr, info)
         elif etype == 'control':
-            jax_expr = self._jax_control(expr)
+            jax_expr = self._jax_control(expr, info)
         elif etype == 'randomvar':
-            jax_expr = self._jax_random(expr)
+            jax_expr = self._jax_random(expr, info)
         elif etype == 'randomvector':
-            jax_expr = self._jax_random_vector(expr)
+            jax_expr = self._jax_random_vector(expr, info)
         elif etype == 'matrix':
-            jax_expr = self._jax_matrix(expr)
+            jax_expr = self._jax_matrix(expr, info)
         else:
             raise RDDLNotImplementedError(
                 f'Internal error: expression type {expr} is not supported.\n' + 
@@ -437,8 +450,8 @@ class JaxRDDLCompiler:
     def _jax_cast(self, jax_expr, dtype):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_CAST']
         
-        def _jax_wrapped_cast(x, key):
-            val, key, err = jax_expr(x, key)
+        def _jax_wrapped_cast(x, params, key):
+            val, key, err = jax_expr(x, params, key)
             sample = jnp.asarray(val, dtype=dtype)
             invalid_cast = jnp.logical_and(
                 jnp.logical_not(jnp.can_cast(val, dtype)),
@@ -452,11 +465,11 @@ class JaxRDDLCompiler:
     # leaves
     # ===========================================================================
     
-    def _jax_constant(self, expr):
+    def _jax_constant(self, expr, info):
         NORMAL = JaxRDDLCompiler.ERROR_CODES['NORMAL']
         cached_value = self.traced.cached_sim_info(expr)
         
-        def _jax_wrapped_constant(_, key):
+        def _jax_wrapped_constant(x, params, key):
             sample = jnp.asarray(cached_value)
             return sample, key, NORMAL
 
@@ -465,12 +478,12 @@ class JaxRDDLCompiler:
     def _jax_pvar_slice(self, _slice):
         NORMAL = JaxRDDLCompiler.ERROR_CODES['NORMAL']
         
-        def _jax_wrapped_pvar_slice(x, key):
+        def _jax_wrapped_pvar_slice(x, params, key):
             return _slice, key, NORMAL
         
         return _jax_wrapped_pvar_slice
             
-    def _jax_pvar(self, expr):
+    def _jax_pvar(self, expr, info):
         NORMAL = JaxRDDLCompiler.ERROR_CODES['NORMAL']
         var, pvars = expr.args  
         is_value, cached_info = self.traced.cached_sim_info(expr)
@@ -480,7 +493,7 @@ class JaxRDDLCompiler:
         if is_value:
             cached_value = cached_info
 
-            def _jax_wrapped_object(_, key):
+            def _jax_wrapped_object(x, params, key):
                 sample = jnp.asarray(cached_value)
                 return sample, key, NORMAL
             
@@ -489,7 +502,7 @@ class JaxRDDLCompiler:
         # boundary case: no shape information (e.g. scalar pvar)
         elif cached_info is None:
             
-            def _jax_wrapped_pvar_scalar(x, key):
+            def _jax_wrapped_pvar_scalar(x, params, key):
                 sample = jnp.asarray(x[var])
                 return sample, key, NORMAL
             
@@ -502,17 +515,17 @@ class JaxRDDLCompiler:
             # compile nested expressions
             if slices and op_code == RDDLObjectsTracer.NUMPY_OP_CODE.NESTED_SLICE:
                 
-                jax_nested_expr = [(self._jax(arg) 
+                jax_nested_expr = [(self._jax(arg, info) 
                                     if _slice is None 
                                     else self._jax_pvar_slice(_slice))
                                    for (arg, _slice) in zip(pvars, slices)]    
                 
-                def _jax_wrapped_pvar_tensor_nested(x, key):
+                def _jax_wrapped_pvar_tensor_nested(x, params, key):
                     error = NORMAL
                     sample = jnp.asarray(x[var])
                     new_slices = [None] * len(jax_nested_expr)
                     for (i, jax_expr) in enumerate(jax_nested_expr):
-                        new_slices[i], key, err = jax_expr(x, key)
+                        new_slices[i], key, err = jax_expr(x, params, key)
                         error |= err
                     new_slices = tuple(new_slices)
                     sample = sample[new_slices]
@@ -523,7 +536,7 @@ class JaxRDDLCompiler:
             # tensor variable but no nesting  
             else:
     
-                def _jax_wrapped_pvar_tensor_non_nested(x, key):
+                def _jax_wrapped_pvar_tensor_non_nested(x, params, key):
                     sample = jnp.asarray(x[var])
                     if slices:
                         sample = sample[slices]
@@ -542,15 +555,16 @@ class JaxRDDLCompiler:
     # mathematical
     # ===========================================================================
     
-    @staticmethod
-    def _jax_unary(jax_expr, jax_op, at_least_int=False, check_dtype=None):
+    def _jax_unary(self, jax_expr, jax_op, jax_param,
+                   at_least_int=False, check_dtype=None):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_CAST']
-        
-        def _jax_wrapped_unary_op(x, key):
-            sample, key, err = jax_expr(x, key)
+
+        def _jax_wrapped_unary_op(x, params, key):
+            sample, key, err = jax_expr(x, params, key)
             if at_least_int:
                 sample = 1 * sample
-            sample = jax_op(sample)
+            param = params.get(jax_param, None)
+            sample = jax_op(sample, param)
             if check_dtype is not None:
                 invalid_cast = jnp.logical_not(jnp.can_cast(sample, check_dtype))
                 err |= (invalid_cast * ERR)
@@ -558,17 +572,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_unary_op
     
-    @staticmethod
-    def _jax_binary(jax_lhs, jax_rhs, jax_op, at_least_int=False, check_dtype=None):
+    def _jax_binary(self, jax_lhs, jax_rhs, jax_op, jax_param,
+                    at_least_int=False, check_dtype=None):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_CAST']
         
-        def _jax_wrapped_binary_op(x, key):
-            sample1, key, err1 = jax_lhs(x, key)
-            sample2, key, err2 = jax_rhs(x, key)
+        def _jax_wrapped_binary_op(x, params, key):
+            sample1, key, err1 = jax_lhs(x, params, key)
+            sample2, key, err2 = jax_rhs(x, params, key)
             if at_least_int:
                 sample1 = 1 * sample1
                 sample2 = 1 * sample2
-            sample = jax_op(sample1, sample2)
+            param = params.get(jax_param, None)
+            sample = jax_op(sample1, sample2, param)
             err = err1 | err2
             if check_dtype is not None:
                 invalid_cast = jnp.logical_not(jnp.logical_and(
@@ -578,8 +593,20 @@ class JaxRDDLCompiler:
             return sample, key, err
         
         return _jax_wrapped_binary_op
-        
-    def _jax_arithmetic(self, expr):
+    
+    def _unwrap(self, op, expr_id, info):
+        jax_op, name = op, None
+        if isinstance(op, tuple):
+            jax_op, param = op
+            if param is not None:
+                name, value = param
+                name = f'{name}_{expr_id}'
+                if name in info:
+                    raise Exception(f'Model parameter {name} is already defined.')
+                info[name] = value
+        return jax_op, name
+    
+    def _jax_arithmetic(self, expr, info):
         _, op = expr.etype
         valid_ops = self.ARITHMETIC_OPS
         JaxRDDLCompiler._check_valid_op(expr, valid_ops)
@@ -589,34 +616,34 @@ class JaxRDDLCompiler:
         
         if n == 1 and op == '-':
             arg, = args
-            jax_expr = self._jax(arg)
-            return JaxRDDLCompiler._jax_unary(
-                jax_expr, jnp.negative, at_least_int=True)
+            jax_expr = self._jax(arg, info)
+            jax_op, jax_param = self._unwrap(self.NEGATIVE, expr.id, info)
+            return self._jax_unary(jax_expr, jax_op, jax_param, at_least_int=True)
                     
         elif n == 2:
             lhs, rhs = args
-            jax_lhs = self._jax(lhs)
-            jax_rhs = self._jax(rhs)
-            jax_op = valid_ops[op]
-            return JaxRDDLCompiler._jax_binary(
-                jax_lhs, jax_rhs, jax_op, at_least_int=True)
+            jax_lhs = self._jax(lhs, info)
+            jax_rhs = self._jax(rhs, info)
+            jax_op, jax_param = self._unwrap(valid_ops[op], expr.id, info)
+            return self._jax_binary(
+                jax_lhs, jax_rhs, jax_op, jax_param, at_least_int=True)
         
         JaxRDDLCompiler._check_num_args(expr, 2)
     
-    def _jax_relational(self, expr):
+    def _jax_relational(self, expr, info):
         _, op = expr.etype
         valid_ops = self.RELATIONAL_OPS
         JaxRDDLCompiler._check_valid_op(expr, valid_ops)
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         lhs, rhs = expr.args
-        jax_lhs = self._jax(lhs)
-        jax_rhs = self._jax(rhs)
-        jax_op = valid_ops[op]
-        return JaxRDDLCompiler._jax_binary(
-            jax_lhs, jax_rhs, jax_op, at_least_int=True)
+        jax_lhs = self._jax(lhs, info)
+        jax_rhs = self._jax(rhs, info)
+        jax_op, jax_param = self._unwrap(valid_ops[op], expr.id, info)
+        return self._jax_binary(
+            jax_lhs, jax_rhs, jax_op, jax_param, at_least_int=True)
            
-    def _jax_logical(self, expr):
+    def _jax_logical(self, expr, info):
         _, op = expr.etype
         valid_ops = self.LOGICAL_OPS    
         JaxRDDLCompiler._check_valid_op(expr, valid_ops)
@@ -626,21 +653,21 @@ class JaxRDDLCompiler:
         
         if n == 1 and op == '~':
             arg, = args
-            jax_expr = self._jax(arg)
-            return JaxRDDLCompiler._jax_unary(
-                jax_expr, self.LOGICAL_NOT, check_dtype=bool)
+            jax_expr = self._jax(arg, info)
+            jax_op, jax_param = self._unwrap(self.LOGICAL_NOT, expr.id, info)
+            return self._jax_unary(jax_expr, jax_op, jax_param, check_dtype=bool)
         
         elif n == 2:
             lhs, rhs = args
-            jax_lhs = self._jax(lhs)
-            jax_rhs = self._jax(rhs)
-            jax_op = valid_ops[op]
-            return JaxRDDLCompiler._jax_binary(
-                jax_lhs, jax_rhs, jax_op, check_dtype=bool)
+            jax_lhs = self._jax(lhs, info)
+            jax_rhs = self._jax(rhs, info)
+            jax_op, jax_param = self._unwrap(valid_ops[op], expr.id, info)
+            return self._jax_binary(
+                jax_lhs, jax_rhs, jax_op, jax_param, check_dtype=bool)
         
         JaxRDDLCompiler._check_num_args(expr, 2)
     
-    def _jax_aggregation(self, expr):
+    def _jax_aggregation(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_CAST']
         
         _, op = expr.etype
@@ -651,79 +678,85 @@ class JaxRDDLCompiler:
         * _, arg = expr.args  
         _, axes = self.traced.cached_sim_info(expr)
         
-        jax_expr = self._jax(arg)
-        jax_op = valid_ops[op]        
+        jax_expr = self._jax(arg, info)
+        jax_op, jax_param = self._unwrap(valid_ops[op], expr.id, info)
         
-        def _jax_wrapped_aggregation(x, key):
-            sample, key, err = jax_expr(x, key)
+        def _jax_wrapped_aggregation(x, params, key):
+            sample, key, err = jax_expr(x, params, key)
             if is_floating:
                 sample = 1 * sample
             else:
                 invalid_cast = jnp.logical_not(jnp.can_cast(sample, bool))
                 err |= (invalid_cast * ERR)
-            sample = jax_op(sample, axis=axes)
+            param = params.get(jax_param, None)
+            sample = jax_op(sample, axis=axes, param=param)
             return sample, key, err
         
         return _jax_wrapped_aggregation
                
-    def _jax_functional(self, expr):
+    def _jax_functional(self, expr, info):
         _, op = expr.etype
         
         # unary function
         if op in self.KNOWN_UNARY:
             JaxRDDLCompiler._check_num_args(expr, 1)                            
             arg, = expr.args
-            jax_expr = self._jax(arg)
-            jax_op = self.KNOWN_UNARY[op]
-            return JaxRDDLCompiler._jax_unary(
-                jax_expr, jax_op, at_least_int=True)
+            jax_expr = self._jax(arg, info)
+            jax_op, jax_param = self._unwrap(self.KNOWN_UNARY[op], expr.id, info)
+            return self._jax_unary(jax_expr, jax_op, jax_param, at_least_int=True)
             
         # binary function
         elif op in self.KNOWN_BINARY:
             JaxRDDLCompiler._check_num_args(expr, 2)                
             lhs, rhs = expr.args
-            jax_lhs = self._jax(lhs)
-            jax_rhs = self._jax(rhs)
-            jax_op = self.KNOWN_BINARY[op]
-            return JaxRDDLCompiler._jax_binary(
-                jax_lhs, jax_rhs, jax_op, at_least_int=True)
+            jax_lhs = self._jax(lhs, info)
+            jax_rhs = self._jax(rhs, info)
+            jax_op, jax_param = self._unwrap(self.KNOWN_BINARY[op], expr.id, info)
+            return self._jax_binary(
+                jax_lhs, jax_rhs, jax_op, jax_param, at_least_int=True)
         
         raise RDDLNotImplementedError(
-                f'Function {op} is not supported.\n' + print_stack_trace(expr))   
+            f'Function {op} is not supported.\n' + 
+            print_stack_trace(expr))   
     
     # ===========================================================================
     # control flow
     # ===========================================================================
     
-    def _jax_control(self, expr):
+    def _jax_control(self, expr, info):
         _, op = expr.etype        
         if op == 'if':
-            return self._jax_if(expr)
+            return self._jax_if(expr, info)
         elif op == 'switch':
-            return self._jax_switch(expr)
+            return self._jax_switch(expr, info)
         
         raise RDDLNotImplementedError(
-                f'Control operator {op} is not supported.\n' + 
-                print_stack_trace(expr))   
+            f'Control operator {op} is not supported.\n' + 
+            print_stack_trace(expr))   
     
     def _jax_if_helper(self):
-        return jnp.where
+        
+        def _jax_wrapped_if_calc_exact(c, a, b, param):
+            return jnp.where(c, a, b)
+        
+        return _jax_wrapped_if_calc_exact
     
-    def _jax_if(self, expr):
+    def _jax_if(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_CAST']
         JaxRDDLCompiler._check_num_args(expr, 3)
-        jax_if = self._jax_if_helper()
+        jax_if, jax_param = self._unwrap(self._jax_if_helper(), expr.id, info)
         
         pred, if_true, if_false = expr.args        
-        jax_pred = self._jax(pred)
-        jax_true = self._jax(if_true)
-        jax_false = self._jax(if_false)
+        jax_pred = self._jax(pred, info)
+        jax_true = self._jax(if_true, info)
+        jax_false = self._jax(if_false, info)
         
-        def _jax_wrapped_if_then_else(x, key):
-            sample1, key, err1 = jax_pred(x, key)
-            sample2, key, err2 = jax_true(x, key)
-            sample3, key, err3 = jax_false(x, key)
-            sample = jax_if(sample1, sample2, sample3)
+        def _jax_wrapped_if_then_else(x, params, key):
+            sample1, key, err1 = jax_pred(x, params, key)
+            sample2, key, err2 = jax_true(x, params, key)
+            sample3, key, err3 = jax_false(x, params, key)
+            param = params.get(jax_param, None)
+            sample = jax_if(sample1, sample2, sample3, param)
             err = err1 | err2 | err3
             invalid_cast = jnp.logical_not(jnp.can_cast(sample1, bool))
             err |= (invalid_cast * ERR)
@@ -733,39 +766,41 @@ class JaxRDDLCompiler:
     
     def _jax_switch_helper(self):
         
-        def _jax_switch_calc_exact(pred, cases):
+        def _jax_wrapped_switch_calc_exact(pred, cases, param):
             pred = pred[jnp.newaxis, ...]
             sample = jnp.take_along_axis(cases, pred, axis=0)
             assert sample.shape[0] == 1
             return sample[0, ...]
 
-        return _jax_switch_calc_exact
+        return _jax_wrapped_switch_calc_exact
         
-    def _jax_switch(self, expr):
+    def _jax_switch(self, expr, info):
         pred, *_ = expr.args             
-        jax_pred = self._jax(pred)
-        jax_switch = self._jax_switch_helper()
+        jax_pred = self._jax(pred, info)
+        jax_switch, jax_param = self._unwrap(
+            self._jax_switch_helper(), expr.id, info)
         
         # wrap cases as JAX expressions
         cases, default = self.traced.cached_sim_info(expr) 
-        jax_default = None if default is None else self._jax(default)
-        jax_cases = [(jax_default if _case is None else self._jax(_case))
+        jax_default = None if default is None else self._jax(default, info)
+        jax_cases = [(jax_default if _case is None else self._jax(_case, info))
                      for _case in cases]
                     
-        def _jax_wrapped_switch(x, key):
+        def _jax_wrapped_switch(x, params, key):
             
             # sample predicate
-            sample_pred, key, err = jax_pred(x, key) 
+            sample_pred, key, err = jax_pred(x, params, key) 
             
             # sample cases
             sample_cases = [None] * len(jax_cases)
             for (i, jax_case) in enumerate(jax_cases):
-                sample_cases[i], key, err_case = jax_case(x, key)
+                sample_cases[i], key, err_case = jax_case(x, params, key)
                 err |= err_case                
             sample_cases = jnp.asarray(sample_cases)
             
             # predicate (enum) is an integer - use it to extract from case array
-            sample = jax_switch(sample_pred, sample_cases)
+            param = params.get(jax_param, None)
+            sample = jax_switch(sample_pred, sample_cases, param)
             return sample, key, err    
         
         return _jax_wrapped_switch
@@ -802,72 +837,72 @@ class JaxRDDLCompiler:
     # Geometric: (implement safe floor)
     # Student: (no reparameterization)
     
-    def _jax_random(self, expr):
+    def _jax_random(self, expr, info):
         _, name = expr.etype
         if name == 'KronDelta':
-            return self._jax_kron(expr)        
+            return self._jax_kron(expr, info)        
         elif name == 'DiracDelta':
-            return self._jax_dirac(expr)
+            return self._jax_dirac(expr, info)
         elif name == 'Uniform':
-            return self._jax_uniform(expr)
+            return self._jax_uniform(expr, info)
         elif name == 'Bernoulli':
-            return self._jax_bernoulli(expr)
+            return self._jax_bernoulli(expr, info)
         elif name == 'Normal':
-            return self._jax_normal(expr)  
+            return self._jax_normal(expr, info)  
         elif name == 'Poisson':
-            return self._jax_poisson(expr)
+            return self._jax_poisson(expr, info)
         elif name == 'Exponential':
-            return self._jax_exponential(expr)
+            return self._jax_exponential(expr, info)
         elif name == 'Weibull':
-            return self._jax_weibull(expr) 
+            return self._jax_weibull(expr, info) 
         elif name == 'Gamma':
-            return self._jax_gamma(expr)
+            return self._jax_gamma(expr, info)
         elif name == 'Binomial':
-            return self._jax_binomial(expr)
+            return self._jax_binomial(expr, info)
         elif name == 'NegativeBinomial':
-            return self._jax_negative_binomial(expr)
+            return self._jax_negative_binomial(expr, info)
         elif name == 'Beta':
-            return self._jax_beta(expr)
+            return self._jax_beta(expr, info)
         elif name == 'Geometric':
-            return self._jax_geometric(expr)
+            return self._jax_geometric(expr, info)
         elif name == 'Pareto':
-            return self._jax_pareto(expr)
+            return self._jax_pareto(expr, info)
         elif name == 'Student':
-            return self._jax_student(expr)
+            return self._jax_student(expr, info)
         elif name == 'Gumbel':
-            return self._jax_gumbel(expr)
+            return self._jax_gumbel(expr, info)
         elif name == 'Laplace':
-            return self._jax_laplace(expr)
+            return self._jax_laplace(expr, info)
         elif name == 'Cauchy':
-            return self._jax_cauchy(expr)
+            return self._jax_cauchy(expr, info)
         elif name == 'Gompertz':
-            return self._jax_gompertz(expr)
+            return self._jax_gompertz(expr, info)
         elif name == 'ChiSquare':
-            return self._jax_chisquare(expr)
+            return self._jax_chisquare(expr, info)
         elif name == 'Kumaraswamy':
-            return self._jax_kumaraswamy(expr)
+            return self._jax_kumaraswamy(expr, info)
         elif name == 'Discrete':
-            return self._jax_discrete(expr, unnorm=False)
+            return self._jax_discrete(expr, info, unnorm=False)
         elif name == 'UnnormDiscrete':
-            return self._jax_discrete(expr, unnorm=True)
+            return self._jax_discrete(expr, info, unnorm=True)
         elif name == 'Discrete(p)':
-            return self._jax_discrete_pvar(expr, unnorm=False)
+            return self._jax_discrete_pvar(expr, info, unnorm=False)
         elif name == 'UnnormDiscrete(p)':
-            return self._jax_discrete_pvar(expr, unnorm=True)
+            return self._jax_discrete_pvar(expr, info, unnorm=True)
         else:
             raise RDDLNotImplementedError(
                 f'Distribution {name} is not supported.\n' + 
                 print_stack_trace(expr))
         
-    def _jax_kron(self, expr):
+    def _jax_kron(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_KRON_DELTA']
         JaxRDDLCompiler._check_num_args(expr, 1)
         arg, = expr.args
-        arg = self._jax(arg)
+        arg = self._jax(arg, info)
         
         # just check that the sample can be cast to int
-        def _jax_wrapped_distribution_kron(x, key):
-            sample, key, err = arg(x, key)
+        def _jax_wrapped_distribution_kron(x, params, key):
+            sample, key, err = arg(x, params, key)
             invalid_cast = jnp.logical_not(
                 jnp.can_cast(sample, JaxRDDLCompiler.INT))
             err |= (invalid_cast * ERR)
@@ -875,24 +910,24 @@ class JaxRDDLCompiler:
                         
         return _jax_wrapped_distribution_kron
     
-    def _jax_dirac(self, expr):
+    def _jax_dirac(self, expr, info):
         JaxRDDLCompiler._check_num_args(expr, 1)
         arg, = expr.args
-        arg = self._jax(arg, dtype=JaxRDDLCompiler.REAL)
+        arg = self._jax(arg, info, dtype=JaxRDDLCompiler.REAL)
         return arg
     
-    def _jax_uniform(self, expr):
+    def _jax_uniform(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_UNIFORM']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_lb, arg_ub = expr.args
-        jax_lb = self._jax(arg_lb)
-        jax_ub = self._jax(arg_ub)
+        jax_lb = self._jax(arg_lb, info)
+        jax_ub = self._jax(arg_ub, info)
         
         # reparameterization trick U(a, b) = a + (b - a) * U(0, 1)
-        def _jax_wrapped_distribution_uniform(x, key):
-            lb, key, err1 = jax_lb(x, key)
-            ub, key, err2 = jax_ub(x, key)
+        def _jax_wrapped_distribution_uniform(x, params, key):
+            lb, key, err1 = jax_lb(x, params, key)
+            ub, key, err2 = jax_ub(x, params, key)
             key, subkey = random.split(key)
             U = random.uniform(
                 key=subkey, shape=jnp.shape(lb), dtype=JaxRDDLCompiler.REAL)
@@ -903,18 +938,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_uniform
     
-    def _jax_normal(self, expr):
+    def _jax_normal(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_NORMAL']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_mean, arg_var = expr.args
-        jax_mean = self._jax(arg_mean)
-        jax_var = self._jax(arg_var)
+        jax_mean = self._jax(arg_mean, info)
+        jax_var = self._jax(arg_var, info)
         
         # reparameterization trick N(m, s^2) = m + s * N(0, 1)
-        def _jax_wrapped_distribution_normal(x, key):
-            mean, key, err1 = jax_mean(x, key)
-            var, key, err2 = jax_var(x, key)
+        def _jax_wrapped_distribution_normal(x, params, key):
+            mean, key, err1 = jax_mean(x, params, key)
+            var, key, err2 = jax_var(x, params, key)
             std = jnp.sqrt(var)
             key, subkey = random.split(key)
             Z = random.normal(
@@ -926,16 +961,16 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_normal
     
-    def _jax_exponential(self, expr):
+    def _jax_exponential(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_EXPONENTIAL']
         JaxRDDLCompiler._check_num_args(expr, 1)
         
         arg_scale, = expr.args
-        jax_scale = self._jax(arg_scale)
+        jax_scale = self._jax(arg_scale, info)
         
         # reparameterization trick Exp(s) = s * Exp(1)
-        def _jax_wrapped_distribution_exp(x, key):
-            scale, key, err = jax_scale(x, key)
+        def _jax_wrapped_distribution_exp(x, params, key):
+            scale, key, err = jax_scale(x, params, key)
             key, subkey = random.split(key)
             Exp1 = random.exponential(
                 key=subkey, shape=jnp.shape(scale), dtype=JaxRDDLCompiler.REAL)
@@ -946,18 +981,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_exp
     
-    def _jax_weibull(self, expr):
+    def _jax_weibull(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_WEIBULL']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_shape, arg_scale = expr.args
-        jax_shape = self._jax(arg_shape)
-        jax_scale = self._jax(arg_scale)
+        jax_shape = self._jax(arg_shape, info)
+        jax_scale = self._jax(arg_scale, info)
         
         # reparameterization trick W(s, r) = r * (-ln(1 - U(0, 1))) ** (1 / s)
-        def _jax_wrapped_distribution_weibull(x, key):
-            shape, key, err1 = jax_shape(x, key)
-            scale, key, err2 = jax_scale(x, key)
+        def _jax_wrapped_distribution_weibull(x, params, key):
+            shape, key, err1 = jax_shape(x, params, key)
+            scale, key, err2 = jax_scale(x, params, key)
             key, subkey = random.split(key)
             U = random.uniform(
                 key=subkey, shape=jnp.shape(scale), dtype=JaxRDDLCompiler.REAL)
@@ -969,37 +1004,43 @@ class JaxRDDLCompiler:
         return _jax_wrapped_distribution_weibull
     
     def _jax_bernoulli_helper(self):
-        return random.bernoulli
         
-    def _jax_bernoulli(self, expr):
+        def _jax_wrapped_calc_bernoulli_exact(key, prob, param):
+            return random.bernoulli(key, prob)
+        
+        return _jax_wrapped_calc_bernoulli_exact
+        
+    def _jax_bernoulli(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_BERNOULLI']
         JaxRDDLCompiler._check_num_args(expr, 1)
-        bernoulli = self._jax_bernoulli_helper()
+        jax_bern, jax_param = self._unwrap(
+            self._jax_bernoulli_helper(), expr.id, info)
         
         arg_prob, = expr.args
-        jax_prob = self._jax(arg_prob)
+        jax_prob = self._jax(arg_prob, info)
         
         # uses the implicit JAX subroutine
-        def _jax_wrapped_distribution_bernoulli(x, key):
-            prob, key, err = jax_prob(x, key)
+        def _jax_wrapped_distribution_bernoulli(x, params, key):
+            prob, key, err = jax_prob(x, params, key)
             key, subkey = random.split(key)
-            sample = bernoulli(subkey, prob)
+            param = params.get(jax_param, None)
+            sample = jax_bern(subkey, prob, param)
             out_of_bounds = jnp.logical_not(jnp.all((prob >= 0) & (prob <= 1)))
             err |= (out_of_bounds * ERR)
             return sample, key, err
         
         return _jax_wrapped_distribution_bernoulli
     
-    def _jax_poisson(self, expr):
+    def _jax_poisson(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_POISSON']
         JaxRDDLCompiler._check_num_args(expr, 1)
         
         arg_rate, = expr.args
-        jax_rate = self._jax(arg_rate)
+        jax_rate = self._jax(arg_rate, info)
         
         # uses the implicit JAX subroutine
-        def _jax_wrapped_distribution_poisson(x, key):
-            rate, key, err = jax_rate(x, key)
+        def _jax_wrapped_distribution_poisson(x, params, key):
+            rate, key, err = jax_rate(x, params, key)
             key, subkey = random.split(key)
             sample = random.poisson(
                 key=subkey, lam=rate, dtype=JaxRDDLCompiler.INT)
@@ -1009,19 +1050,19 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_poisson
     
-    def _jax_gamma(self, expr):
+    def _jax_gamma(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_GAMMA']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_shape, arg_scale = expr.args
-        jax_shape = self._jax(arg_shape)
-        jax_scale = self._jax(arg_scale)
+        jax_shape = self._jax(arg_shape, info)
+        jax_scale = self._jax(arg_scale, info)
         
         # partial reparameterization trick Gamma(s, r) = r * Gamma(s, 1)
         # uses the implicit JAX subroutine for Gamma(s, 1) 
-        def _jax_wrapped_distribution_gamma(x, key):
-            shape, key, err1 = jax_shape(x, key)
-            scale, key, err2 = jax_scale(x, key)
+        def _jax_wrapped_distribution_gamma(x, params, key):
+            shape, key, err1 = jax_shape(x, params, key)
+            scale, key, err2 = jax_scale(x, params, key)
             key, subkey = random.split(key)
             Gamma = random.gamma(key=subkey, a=shape, dtype=JaxRDDLCompiler.REAL)
             sample = scale * Gamma
@@ -1031,18 +1072,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_gamma
     
-    def _jax_binomial(self, expr):
+    def _jax_binomial(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_BINOMIAL']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_trials, arg_prob = expr.args
-        jax_trials = self._jax(arg_trials)
-        jax_prob = self._jax(arg_prob)
+        jax_trials = self._jax(arg_trials, info)
+        jax_prob = self._jax(arg_prob, info)
         
         # uses the JAX substrate of tensorflow-probability
-        def _jax_wrapped_distribution_binomial(x, key):
-            trials, key, err2 = jax_trials(x, key)       
-            prob, key, err1 = jax_prob(x, key)
+        def _jax_wrapped_distribution_binomial(x, params, key):
+            trials, key, err2 = jax_trials(x, params, key)       
+            prob, key, err1 = jax_prob(x, params, key)
             trials = jnp.asarray(trials, JaxRDDLCompiler.REAL)
             prob = jnp.asarray(prob, JaxRDDLCompiler.REAL)
             key, subkey = random.split(key)
@@ -1055,18 +1096,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_binomial
     
-    def _jax_negative_binomial(self, expr):
+    def _jax_negative_binomial(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_NEGATIVE_BINOMIAL']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_trials, arg_prob = expr.args
-        jax_trials = self._jax(arg_trials)
-        jax_prob = self._jax(arg_prob)
+        jax_trials = self._jax(arg_trials, info)
+        jax_prob = self._jax(arg_prob, info)
         
         # uses the JAX substrate of tensorflow-probability
-        def _jax_wrapped_distribution_negative_binomial(x, key):
-            trials, key, err2 = jax_trials(x, key)       
-            prob, key, err1 = jax_prob(x, key)
+        def _jax_wrapped_distribution_negative_binomial(x, params, key):
+            trials, key, err2 = jax_trials(x, params, key)       
+            prob, key, err1 = jax_prob(x, params, key)
             trials = jnp.asarray(trials, JaxRDDLCompiler.REAL)
             prob = jnp.asarray(prob, JaxRDDLCompiler.REAL)
             key, subkey = random.split(key)
@@ -1080,18 +1121,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_negative_binomial    
         
-    def _jax_beta(self, expr):
+    def _jax_beta(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_BETA']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_shape, arg_rate = expr.args
-        jax_shape = self._jax(arg_shape)
-        jax_rate = self._jax(arg_rate)
+        jax_shape = self._jax(arg_shape, info)
+        jax_rate = self._jax(arg_rate, info)
         
         # uses the implicit JAX subroutine
-        def _jax_wrapped_distribution_beta(x, key):
-            shape, key, err1 = jax_shape(x, key)
-            rate, key, err2 = jax_rate(x, key)
+        def _jax_wrapped_distribution_beta(x, params, key):
+            shape, key, err1 = jax_shape(x, params, key)
+            rate, key, err2 = jax_rate(x, params, key)
             key, subkey = random.split(key)
             sample = random.beta(key=subkey, a=shape, b=rate)
             out_of_bounds = jnp.logical_not(jnp.all((shape > 0) & (rate > 0)))
@@ -1100,40 +1141,42 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_beta
     
-    def _jax_geometric(self, expr):
+    def _jax_geometric(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_GEOMETRIC']
         JaxRDDLCompiler._check_num_args(expr, 1)
         
         arg_prob, = expr.args
-        jax_prob = self._jax(arg_prob)
-        floor_op = self.KNOWN_UNARY['floor']
+        jax_prob = self._jax(arg_prob, info)
+        floor_op, jax_param = self._unwrap(
+            self.KNOWN_UNARY['floor'], expr.id, info)
         
         # reparameterization trick Geom(p) = floor(ln(U(0, 1)) / ln(p)) + 1
-        def _jax_wrapped_distribution_geometric(x, key):
-            prob, key, err = jax_prob(x, key)
+        def _jax_wrapped_distribution_geometric(x, params, key):
+            prob, key, err = jax_prob(x, params, key)
             key, subkey = random.split(key)
             U = random.uniform(
                 key=subkey, shape=jnp.shape(prob), dtype=JaxRDDLCompiler.REAL)
-            sample = floor_op(jnp.log1p(-U) / jnp.log1p(-prob)) + 1
+            param = params.get(jax_param, None)
+            sample = floor_op(jnp.log1p(-U) / jnp.log1p(-prob), param) + 1
             out_of_bounds = jnp.logical_not(jnp.all((prob >= 0) & (prob <= 1)))
             err |= (out_of_bounds * ERR)
             return sample, key, err
         
         return _jax_wrapped_distribution_geometric
     
-    def _jax_pareto(self, expr):
+    def _jax_pareto(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_PARETO']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_shape, arg_scale = expr.args
-        jax_shape = self._jax(arg_shape)
-        jax_scale = self._jax(arg_scale)
+        jax_shape = self._jax(arg_shape, info)
+        jax_scale = self._jax(arg_scale, info)
         
         # partial reparameterization trick Pareto(s, r) = r * Pareto(s, 1)
         # uses the implicit JAX subroutine for Pareto(s, 1) 
-        def _jax_wrapped_distribution_pareto(x, key):
-            shape, key, err1 = jax_shape(x, key)
-            scale, key, err2 = jax_scale(x, key)
+        def _jax_wrapped_distribution_pareto(x, params, key):
+            shape, key, err1 = jax_shape(x, params, key)
+            scale, key, err2 = jax_scale(x, params, key)
             key, subkey = random.split(key)
             sample = scale * random.pareto(key=subkey, b=shape)
             out_of_bounds = jnp.logical_not(jnp.all((shape > 0) & (scale > 0)))
@@ -1142,16 +1185,16 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_pareto
     
-    def _jax_student(self, expr):
+    def _jax_student(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_STUDENT']
         JaxRDDLCompiler._check_num_args(expr, 1)
         
         arg_df, = expr.args
-        jax_df = self._jax(arg_df)
+        jax_df = self._jax(arg_df, info)
         
         # uses the implicit JAX subroutine for student(df)
-        def _jax_wrapped_distribution_t(x, key):
-            df, key, err = jax_df(x, key)
+        def _jax_wrapped_distribution_t(x, params, key):
+            df, key, err = jax_df(x, params, key)
             key, subkey = random.split(key)
             sample = random.t(key=subkey, df=df)
             out_of_bounds = jnp.logical_not(jnp.all(df > 0))
@@ -1160,18 +1203,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_t
     
-    def _jax_gumbel(self, expr):
+    def _jax_gumbel(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_GUMBEL']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_mean, arg_scale = expr.args
-        jax_mean = self._jax(arg_mean)
-        jax_scale = self._jax(arg_scale)
+        jax_mean = self._jax(arg_mean, info)
+        jax_scale = self._jax(arg_scale, info)
         
         # reparameterization trick Gumbel(m, s) = m + s * Gumbel(0, 1)
-        def _jax_wrapped_distribution_gumbel(x, key):
-            mean, key, err1 = jax_mean(x, key)
-            scale, key, err2 = jax_scale(x, key)
+        def _jax_wrapped_distribution_gumbel(x, params, key):
+            mean, key, err1 = jax_mean(x, params, key)
+            scale, key, err2 = jax_scale(x, params, key)
             key, subkey = random.split(key)
             Gumbel01 = random.gumbel(
                 key=subkey, shape=jnp.shape(mean), dtype=JaxRDDLCompiler.REAL)
@@ -1182,18 +1225,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_gumbel
     
-    def _jax_laplace(self, expr):
+    def _jax_laplace(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_LAPLACE']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_mean, arg_scale = expr.args
-        jax_mean = self._jax(arg_mean)
-        jax_scale = self._jax(arg_scale)
+        jax_mean = self._jax(arg_mean, info)
+        jax_scale = self._jax(arg_scale, info)
         
         # reparameterization trick Laplace(m, s) = m + s * Laplace(0, 1)
-        def _jax_wrapped_distribution_laplace(x, key):
-            mean, key, err1 = jax_mean(x, key)
-            scale, key, err2 = jax_scale(x, key)
+        def _jax_wrapped_distribution_laplace(x, params, key):
+            mean, key, err1 = jax_mean(x, params, key)
+            scale, key, err2 = jax_scale(x, params, key)
             key, subkey = random.split(key)
             Laplace01 = random.laplace(
                 key=subkey, shape=jnp.shape(mean), dtype=JaxRDDLCompiler.REAL)
@@ -1204,18 +1247,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_laplace
     
-    def _jax_cauchy(self, expr):
+    def _jax_cauchy(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_CAUCHY']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_mean, arg_scale = expr.args
-        jax_mean = self._jax(arg_mean)
-        jax_scale = self._jax(arg_scale)
+        jax_mean = self._jax(arg_mean, info)
+        jax_scale = self._jax(arg_scale, info)
         
         # reparameterization trick Cauchy(m, s) = m + s * Cauchy(0, 1)
-        def _jax_wrapped_distribution_cauchy(x, key):
-            mean, key, err1 = jax_mean(x, key)
-            scale, key, err2 = jax_scale(x, key)
+        def _jax_wrapped_distribution_cauchy(x, params, key):
+            mean, key, err1 = jax_mean(x, params, key)
+            scale, key, err2 = jax_scale(x, params, key)
             key, subkey = random.split(key)
             Cauchy01 = random.cauchy(
                 key=subkey, shape=jnp.shape(mean), dtype=JaxRDDLCompiler.REAL)
@@ -1226,18 +1269,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_cauchy
     
-    def _jax_gompertz(self, expr):
+    def _jax_gompertz(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_GOMPERTZ']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_shape, arg_scale = expr.args
-        jax_shape = self._jax(arg_shape)
-        jax_scale = self._jax(arg_scale)
+        jax_shape = self._jax(arg_shape, info)
+        jax_scale = self._jax(arg_scale, info)
         
         # reparameterization trick Gompertz(s, r) = ln(1 - log(U(0, 1)) / s) / r
-        def _jax_wrapped_distribution_gompertz(x, key):
-            shape, key, err1 = jax_shape(x, key)
-            scale, key, err2 = jax_scale(x, key)
+        def _jax_wrapped_distribution_gompertz(x, params, key):
+            shape, key, err1 = jax_shape(x, params, key)
+            scale, key, err2 = jax_scale(x, params, key)
             key, subkey = random.split(key)
             U = random.uniform(
                 key=subkey, shape=jnp.shape(scale), dtype=JaxRDDLCompiler.REAL)
@@ -1248,16 +1291,16 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_gompertz
     
-    def _jax_chisquare(self, expr):
+    def _jax_chisquare(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_CHISQUARE']
         JaxRDDLCompiler._check_num_args(expr, 1)
         
         arg_df, = expr.args
-        jax_df = self._jax(arg_df)
+        jax_df = self._jax(arg_df, info)
         
         # use the fact that ChiSquare(df) = Gamma(df/2, 2)
-        def _jax_wrapped_distribution_chisquare(x, key):
-            df, key, err1 = jax_df(x, key)
+        def _jax_wrapped_distribution_chisquare(x, params, key):
+            df, key, err1 = jax_df(x, params, key)
             key, subkey = random.split(key)
             shape = df / 2.0
             Gamma = random.gamma(key=subkey, a=shape, dtype=JaxRDDLCompiler.REAL)
@@ -1268,18 +1311,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_chisquare
     
-    def _jax_kumaraswamy(self, expr):
+    def _jax_kumaraswamy(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_KUMARASWAMY']
         JaxRDDLCompiler._check_num_args(expr, 2)
         
         arg_a, arg_b = expr.args
-        jax_a = self._jax(arg_a)
-        jax_b = self._jax(arg_b)
+        jax_a = self._jax(arg_a, info)
+        jax_b = self._jax(arg_b, info)
         
         # uses the reparameterization K(a, b) = (1 - (1 - U(0, 1))^{1/b})^{1/a}
-        def _jax_wrapped_distribution_kumaraswamy(x, key):
-            a, key, err1 = jax_a(x, key)
-            b, key, err2 = jax_b(x, key)
+        def _jax_wrapped_distribution_kumaraswamy(x, params, key):
+            a, key, err1 = jax_a(x, params, key)
+            b, key, err2 = jax_b(x, params, key)
             key, subkey = random.split(key)
             U = random.uniform(
                 key=subkey, shape=jnp.shape(a), dtype=JaxRDDLCompiler.REAL)            
@@ -1296,7 +1339,7 @@ class JaxRDDLCompiler:
     
     def _jax_discrete_helper(self):
         
-        def _jax_discrete_calc_exact(key, prob):
+        def _jax_wrapped_discrete_calc_exact(key, prob, param):
             logits = jnp.log(prob)
             sample = random.categorical(key=key, logits=logits, axis=-1)
             out_of_bounds = jnp.logical_not(jnp.logical_and(
@@ -1304,23 +1347,24 @@ class JaxRDDLCompiler:
                 jnp.allclose(jnp.sum(prob, axis=-1), 1.0)))
             return sample, out_of_bounds
         
-        return _jax_discrete_calc_exact
+        return _jax_wrapped_discrete_calc_exact
             
-    def _jax_discrete(self, expr, unnorm):
+    def _jax_discrete(self, expr, info, unnorm):
         NORMAL = JaxRDDLCompiler.ERROR_CODES['NORMAL']
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_DISCRETE']
-        jax_discrete = self._jax_discrete_helper()
+        jax_discrete, jax_param = self._unwrap(
+            self._jax_discrete_helper(), expr.id, info)
         
         ordered_args = self.traced.cached_sim_info(expr)
-        jax_probs = [self._jax(arg) for arg in ordered_args]
+        jax_probs = [self._jax(arg, info) for arg in ordered_args]
         
-        def _jax_wrapped_distribution_discrete(x, key):
+        def _jax_wrapped_distribution_discrete(x, params, key):
             
             # sample case probabilities and normalize as needed
             error = NORMAL
             prob = [None] * len(jax_probs)
             for (i, jax_prob) in enumerate(jax_probs):
-                prob[i], key, error_pdf = jax_prob(x, key)
+                prob[i], key, error_pdf = jax_prob(x, params, key)
                 error |= error_pdf
             prob = jnp.stack(prob, axis=-1)
             if unnorm:
@@ -1329,32 +1373,35 @@ class JaxRDDLCompiler:
             
             # dispatch to sampling subroutine
             key, subkey = random.split(key)
-            sample, out_of_bounds = jax_discrete(subkey, prob)
+            param = params.get(jax_param, None)
+            sample, out_of_bounds = jax_discrete(subkey, prob, param)
             error |= (out_of_bounds * ERR)
             return sample, key, error
         
         return _jax_wrapped_distribution_discrete
     
-    def _jax_discrete_pvar(self, expr, unnorm):
+    def _jax_discrete_pvar(self, expr, info, unnorm):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_DISCRETE']
         JaxRDDLCompiler._check_num_args(expr, 1)
-        jax_discrete = self._jax_discrete_helper()
+        jax_discrete, jax_param = self._unwrap(
+            self._jax_discrete_helper(), expr.id, info)
         
         _, args = expr.args
         arg, = args
-        jax_probs = self._jax(arg)
+        jax_probs = self._jax(arg, info)
 
-        def _jax_wrapped_distribution_discrete_pvar(x, key):
+        def _jax_wrapped_distribution_discrete_pvar(x, params, key):
             
             # sample probabilities
-            prob, key, error = jax_probs(x, key)
+            prob, key, error = jax_probs(x, params, key)
             if unnorm:
                 normalizer = jnp.sum(prob, axis=-1, keepdims=True)
                 prob = prob / normalizer
             
             # dispatch to sampling subroutine
             key, subkey = random.split(key)
-            sample, out_of_bounds = jax_discrete(subkey, prob)
+            param = params.get(jax_param, None)
+            sample, out_of_bounds = jax_discrete(subkey, prob, param)
             error |= (out_of_bounds * ERR)
             return sample, key, error
         
@@ -1364,34 +1411,34 @@ class JaxRDDLCompiler:
     # random vectors
     # ===========================================================================
     
-    def _jax_random_vector(self, expr):
+    def _jax_random_vector(self, expr, info):
         _, name = expr.etype
         if name == 'MultivariateNormal':
-            return self._jax_multivariate_normal(expr)   
+            return self._jax_multivariate_normal(expr, info)   
         elif name == 'MultivariateStudent':
-            return self._jax_multivariate_student(expr)  
+            return self._jax_multivariate_student(expr, info)  
         elif name == 'Dirichlet':
-            return self._jax_dirichlet(expr)
+            return self._jax_dirichlet(expr, info)
         elif name == 'Multinomial':
-            return self._jax_multinomial(expr)
+            return self._jax_multinomial(expr, info)
         else:
             raise RDDLNotImplementedError(
                 f'Distribution {name} is not supported.\n' + 
                 print_stack_trace(expr))
     
-    def _jax_multivariate_normal(self, expr): 
+    def _jax_multivariate_normal(self, expr, info): 
         _, args = expr.args
         mean, cov = args
-        jax_mean = self._jax(mean)
-        jax_cov = self._jax(cov)
+        jax_mean = self._jax(mean, info)
+        jax_cov = self._jax(cov, info)
         index, = self.traced.cached_sim_info(expr)
         
         # reparameterization trick MN(m, LL') = LZ + m, where Z ~ Normal(0, 1)
-        def _jax_wrapped_distribution_multivariate_normal(x, key):
+        def _jax_wrapped_distribution_multivariate_normal(x, params, key):
             
             # sample the mean and covariance
-            sample_mean, key, err1 = jax_mean(x, key)
-            sample_cov, key, err2 = jax_cov(x, key)
+            sample_mean, key, err1 = jax_mean(x, params, key)
+            sample_cov, key, err2 = jax_cov(x, params, key)
             
             # sample Normal(0, 1)
             key, subkey = random.split(key)
@@ -1409,23 +1456,23 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_multivariate_normal
     
-    def _jax_multivariate_student(self, expr):
+    def _jax_multivariate_student(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_MULTIVARIATE_STUDENT']
         
         _, args = expr.args
         mean, cov, df = args
-        jax_mean = self._jax(mean)
-        jax_cov = self._jax(cov)
-        jax_df = self._jax(df)
+        jax_mean = self._jax(mean, info)
+        jax_cov = self._jax(cov, info)
+        jax_df = self._jax(df, info)
         index, = self.traced.cached_sim_info(expr)
         
         # reparameterization trick MN(m, LL') = LZ + m, where Z ~ StudentT(0, 1)
-        def _jax_wrapped_distribution_multivariate_student(x, key):
+        def _jax_wrapped_distribution_multivariate_student(x, params, key):
             
             # sample the mean and covariance and degrees of freedom
-            sample_mean, key, err1 = jax_mean(x, key)
-            sample_cov, key, err2 = jax_cov(x, key)
-            sample_df, key, err3 = jax_df(x, key)
+            sample_mean, key, err1 = jax_mean(x, params, key)
+            sample_cov, key, err2 = jax_cov(x, params, key)
+            sample_df, key, err3 = jax_df(x, params, key)
             out_of_bounds = jnp.logical_not(jnp.all(sample_df > 0))
             
             # sample StudentT(0, 1, df) -- broadcast df to same shape as cov
@@ -1444,17 +1491,17 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_multivariate_student
     
-    def _jax_dirichlet(self, expr):
+    def _jax_dirichlet(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_DIRICHLET']
         
         _, args = expr.args
         alpha, = args
-        jax_alpha = self._jax(alpha)
+        jax_alpha = self._jax(alpha, info)
         index, = self.traced.cached_sim_info(expr)
         
         # sample Gamma(alpha_i, 1) and normalize across i
-        def _jax_wrapped_distribution_dirichlet(x, key):
-            alpha, key, error = jax_alpha(x, key)
+        def _jax_wrapped_distribution_dirichlet(x, params, key):
+            alpha, key, error = jax_alpha(x, params, key)
             out_of_bounds = jnp.logical_not(jnp.all(alpha > 0))
             error |= (out_of_bounds * ERR)
             key, subkey = random.split(key)
@@ -1465,18 +1512,18 @@ class JaxRDDLCompiler:
         
         return _jax_wrapped_distribution_dirichlet
     
-    def _jax_multinomial(self, expr):
+    def _jax_multinomial(self, expr, info):
         ERR = JaxRDDLCompiler.ERROR_CODES['INVALID_PARAM_MULTINOMIAL']
         
         _, args = expr.args
         trials, prob = args
-        jax_trials = self._jax(trials)
-        jax_prob = self._jax(prob)
+        jax_trials = self._jax(trials, info)
+        jax_prob = self._jax(prob, info)
         index, = self.traced.cached_sim_info(expr)
         
-        def _jax_wrapped_distribution_multinomial(x, key):
-            trials, key, err1 = jax_trials(x, key)
-            prob, key, err2 = jax_prob(x, key)
+        def _jax_wrapped_distribution_multinomial(x, params, key):
+            trials, key, err1 = jax_trials(x, params, key)
+            prob, key, err2 = jax_prob(x, params, key)
             trials = jnp.asarray(trials, JaxRDDLCompiler.REAL)
             prob = jnp.asarray(prob, JaxRDDLCompiler.REAL)
             key, subkey = random.split(key)
@@ -1484,9 +1531,9 @@ class JaxRDDLCompiler:
             sample = dist.sample(seed=subkey).astype(JaxRDDLCompiler.INT)
             sample = jnp.moveaxis(sample, source=-1, destination=index)
             out_of_bounds = jnp.logical_not(jnp.all(
-                (prob >= 0) & 
-                jnp.allclose(jnp.sum(prob, axis=-1), 1.0) & 
-                (trials >= 0)))
+                (prob >= 0)
+                & jnp.allclose(jnp.sum(prob, axis=-1), 1.0)
+                & (trials >= 0)))
             error = err1 | err2 | (out_of_bounds * ERR)
             return sample, key, error            
         
@@ -1496,38 +1543,38 @@ class JaxRDDLCompiler:
     # matrix algebra
     # ===========================================================================
     
-    def _jax_matrix(self, expr):
+    def _jax_matrix(self, expr, info):
         _, op = expr.etype
         if op == 'det':
-            return self._jax_matrix_det(expr)
+            return self._jax_matrix_det(expr, info)
         elif op == 'inverse':
-            return self._jax_matrix_inv(expr, pseudo=False)
+            return self._jax_matrix_inv(expr, info, pseudo=False)
         elif op == 'pinverse':
-            return self._jax_matrix_inv(expr, pseudo=True)
+            return self._jax_matrix_inv(expr, info, pseudo=True)
         else:
             raise RDDLNotImplementedError(
                 f'Matrix operation {op} is not supported.\n' + 
                 print_stack_trace(expr))
     
-    def _jax_matrix_det(self, expr):
+    def _jax_matrix_det(self, expr, info):
         * _, arg = expr.args
-        jax_arg = self._jax(arg)
+        jax_arg = self._jax(arg, info)
         
-        def _jax_wrapped_matrix_operation_det(x, key):
-            sample_arg, key, error = jax_arg(x, key)
+        def _jax_wrapped_matrix_operation_det(x, params, key):
+            sample_arg, key, error = jax_arg(x, params, key)
             sample = jnp.linalg.det(sample_arg)
             return sample, key, error
         
         return _jax_wrapped_matrix_operation_det
     
-    def _jax_matrix_inv(self, expr, pseudo):
+    def _jax_matrix_inv(self, expr, info, pseudo):
         _, arg = expr.args
-        jax_arg = self._jax(arg)
+        jax_arg = self._jax(arg, info)
         indices = self.traced.cached_sim_info(expr)
         op = jnp.linalg.pinv if pseudo else jnp.linalg.inv
         
-        def _jax_wrapped_matrix_operation_inv(x, key):
-            sample_arg, key, error = jax_arg(x, key)
+        def _jax_wrapped_matrix_operation_inv(x, params, key):
+            sample_arg, key, error = jax_arg(x, params, key)
             sample = op(sample_arg)
             sample = jnp.moveaxis(sample, source=(-2, -1), destination=indices)
             return sample, key, error

--- a/pyRDDLGym/Core/Jax/JaxRDDLLogic.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLLogic.py
@@ -44,17 +44,20 @@ class FuzzyLogic:
     def __init__(self, tnorm: TNorm=ProductTNorm(),
                  complement: Complement=StandardComplement(),
                  weight: float=10.0,
+                 error: float=1e-12,
                  eps: float=1e-12):
         '''Creates a new fuzzy logic in Jax.
         
         :param tnorm: fuzzy operator for logical AND
         :param complement: fuzzy operator for logical NOT
         :param weight: a concentration parameter (larger means better accuracy)
+        :param error: an error parameter (e.g. floor) (smaller means better accuracy)
         :param eps: small positive float to mitigate underflow
         '''
         self.tnorm = tnorm
         self.complement = complement
         self.weight = weight
+        self.error = error
         self.eps = eps
         
     # ===========================================================================
@@ -236,7 +239,7 @@ class FuzzyLogic:
         def _jax_wrapped_calc_floor_approx(x, param):
             return x - self._sawtooth(x, param)
         
-        new_param = ('error_floor', 1e-12)
+        new_param = ('error_floor', self.error)
         return _jax_wrapped_calc_floor_approx, new_param
     
     def ceil(self):

--- a/pyRDDLGym/Core/Jax/JaxRDDLLogic.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLLogic.py
@@ -178,7 +178,8 @@ class FuzzyLogic:
                 sample += jax.lax.stop_gradient(hard_sample - sample)
             return sample
         
-        new_param = ('weight_greater', self.weight)
+        tags = ('weight', 'greater')
+        new_param = (tags, self.weight)
         return _jax_wrapped_calc_geq_approx, new_param
     
     def greater(self):
@@ -212,7 +213,8 @@ class FuzzyLogic:
                 sample += jax.lax.stop_gradient(hard_sample - sample)
             return sample
         
-        new_param = ('weight_equal', self.weight)
+        tags = ('weight', 'equal')
+        new_param = (tags, self.weight)
         return _jax_wrapped_calc_equal_approx, new_param
     
     def notEqual(self):
@@ -240,7 +242,8 @@ class FuzzyLogic:
                 sample += jax.lax.stop_gradient(hard_sample - sample)
             return sample
         
-        new_param = ('weight_signum', self.weight)
+        tags = ('weight', 'signum')
+        new_param = (tags, self.weight)
         return _jax_wrapped_calc_signum_approx, new_param
     
     def _sawtooth(self, x, d):
@@ -264,7 +267,8 @@ class FuzzyLogic:
                 sample += jax.lax.stop_gradient(hard_sample - sample)
             return sample
         
-        new_param = ('error_floor', self.error)
+        tags = ('error', 'floor')
+        new_param = (tags, self.error)
         return _jax_wrapped_calc_floor_approx, new_param
     
     def ceil(self):
@@ -335,7 +339,8 @@ class FuzzyLogic:
                 sample += jax.lax.stop_gradient(hard_sample - sample)
             return sample
         
-        new_param = ('weight_argmax', self.weight)
+        tags = ('weight', 'argmax')
+        new_param = (tags, self.weight)
         return _jax_wrapped_calc_argmax_approx, new_param
     
     def argmin(self):
@@ -377,7 +382,8 @@ class FuzzyLogic:
                 sample += jax.lax.stop_gradient(hard_sample - sample)
             return sample
         
-        new_param = ('weight_switch', self.weight)
+        tags = ('weight', 'switch')
+        new_param = (tags, self.weight)
         return _jax_wrapped_calc_switch_approx, new_param
     
     # ===========================================================================

--- a/pyRDDLGym/Core/Jax/JaxRDDLLogic.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLLogic.py
@@ -250,7 +250,7 @@ class FuzzyLogic:
     #     sqr = 2.0 * jnp.arctan(jnp.sin(pi * x) / d) / pi
     #     swt = (1.0 + trg * sqr) / 2.0
     #     return swt        
-        
+    #
     # def floor(self):
     #     warnings.warn('Using the replacement rule: '
     #                   'floor(x) --> x - sawtooth(x), where sawtooth is a '
@@ -279,8 +279,8 @@ class FuzzyLogic:
     
     def ceil(self):
         warnings.warn('Using the replacement rule: '
-                      'ceil(x) --> x - 0.5 - approx(x - 0.5), where approx is a '
-                      'smooth approximation of the step function')
+                      'ceil(x) --> ceil(x - 0.5) + step(x - 0.5), '
+                      'where step is a smooth approximation of the step function')
         debias = 'ceil' in self.debias
         
         def _jax_wrapped_calc_ceil_approx(x, param):

--- a/pyRDDLGym/Core/Jax/JaxRDDLLogic.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLLogic.py
@@ -3,8 +3,6 @@ import jax.numpy as jnp
 import jax.random as random
 import warnings
 
-DEFAULT_WEIGHT = 10.0
-
 
 class Complement:
     
@@ -45,7 +43,7 @@ class FuzzyLogic:
     
     def __init__(self, tnorm: TNorm=ProductTNorm(),
                  complement: Complement=StandardComplement(),
-                 weight: float=DEFAULT_WEIGHT,
+                 weight: float=10.0,
                  eps: float=1e-12):
         '''Creates a new fuzzy logic in Jax.
         
@@ -63,106 +61,225 @@ class FuzzyLogic:
     # logical operators
     # ===========================================================================
      
-    def And(self, a, b):
+    def And(self):
         warnings.warn('Using the replacement rule: '
                       'a ^ b --> tnorm(a, b).', stacklevel=2)
-        return self.tnorm.norm(a, b)
+        
+        _and = self.tnorm.norm
+        
+        def _jax_wrapped_calc_and_approx(a, b, param):
+            return _and(a, b)
+        
+        return _jax_wrapped_calc_and_approx, None
     
-    def Not(self, x):
+    def Not(self):
         warnings.warn('Using the replacement rule: '
                       '~a --> 1 - a', stacklevel=2)
-        return self.complement(x)
+        
+        _not = self.complement
+        
+        def _jax_wrapped_calc_not_approx(x, param):
+            return _not(x)
+        
+        return _jax_wrapped_calc_not_approx, None
     
-    def Or(self, a, b):
-        return self.Not(self.And(self.Not(a), self.Not(b)))
+    def Or(self):
+        warnings.warn('Using the replacement rule: '
+                      'a or b --> tconorm(a, b).', stacklevel=2)
+        
+        _not = self.complement
+        _and = self.tnorm.norm
+        
+        def _jax_wrapped_calc_or_approx(a, b, param):
+            return _not(_and(_not(a), _not(b)))
+        
+        return _jax_wrapped_calc_or_approx, None
+
+    def xor(self):
+        warnings.warn('Using the replacement rule: '
+                      'a xor b --> (a or b) ^ (a ^ b).', stacklevel=2)
+        
+        _not = self.complement
+        _and = self.tnorm.norm
+        
+        def _jax_wrapped_calc_xor_approx(a, b, param):
+            _or = _not(_and(_not(a), _not(b)))
+            return _and(_or(a, b), _not(_and(a, b)))
+        
+        return _jax_wrapped_calc_xor_approx, None
+        
+    def implies(self):
+        warnings.warn('Using the replacement rule: '
+                      'a => b --> ~a ^ b', stacklevel=2)
+        
+        _not = self.complement
+        _and = self.tnorm.norm
+        
+        def _jax_wrapped_calc_implies_approx(a, b, param):
+            return _not(_and(a, _not(b)))
+        
+        return _jax_wrapped_calc_implies_approx, None
     
-    def xor(self, a, b):
-        return self.And(self.Or(a, b), self.Not(self.And(a, b)))
+    def equiv(self):
+        warnings.warn('Using the replacement rule: '
+                      'a <=> b --> (a => b) ^ (b => a)', stacklevel=2)
+        
+        _not = self.complement
+        _and = self.tnorm.norm
+        
+        def _jax_wrapped_calc_equiv_approx(a, b, param):
+            atob = _not(_and(a, _not(b)))
+            btoa = _not(_and(b, _not(a)))
+            return _and(atob, btoa)
+        
+        return _jax_wrapped_calc_equiv_approx, None
     
-    def implies(self, a, b):
-        return self.Or(self.Not(a), b)
-    
-    def equiv(self, a, b):
-        return self.And(self.implies(a, b), self.implies(b, a))
-    
-    def forall(self, x, axis=None):
+    def forall(self):
         warnings.warn('Using the replacement rule: '
                       'forall(a) --> tnorm(a[1], tnorm(a[2], ...))', stacklevel=2)
-        return self.tnorm.norms(x, axis=axis)
+        
+        _forall = self.tnorm.norms
+        
+        def _jax_wrapped_calc_forall_approx(x, axis, param):
+            return _forall(x, axis=axis)
+        
+        return _jax_wrapped_calc_forall_approx, None
     
-    def exists(self, x, axis=None):
-        return self.Not(self.forall(self.Not(x), axis=axis))
+    def exists(self):
+        _not = self.complement
+        jax_forall, jax_param = self.forall()
+        
+        def _jax_wrapped_calc_exists_approx(x, axis, param):
+            return _not(jax_forall(_not(x), axis, param))
+        
+        return _jax_wrapped_calc_exists_approx, jax_param
     
     # ===========================================================================
     # comparison operators
     # ===========================================================================
      
-    def greaterEqual(self, a, b):
+    def greaterEqual(self):
         warnings.warn('Using the replacement rule: '
-                      'a >= b --> sigmoid(a - b)', stacklevel=2)
-        return jax.nn.sigmoid(self.weight * (a - b))
+                      'a >=/> b --> sigmoid(a - b)', stacklevel=2)
+        
+        def _jax_wrapped_calc_geq_approx(a, b, param):
+            return jax.nn.sigmoid(param * (a - b))
+        
+        new_param = ('weight_greater', self.weight)
+        return _jax_wrapped_calc_geq_approx, new_param
     
-    def greater(self, a, b):
-        warnings.warn('Using the replacement rule: '
-                      'a > b --> sigmoid(a - b)', stacklevel=2)
-        return jax.nn.sigmoid(self.weight * (a - b))
+    def greater(self):
+        return self.greaterEqual()
     
-    def lessEqual(self, a, b):
-        return self.greaterEqual(-a, -b)
+    def lessEqual(self):
+        jax_geq, jax_param = self.greaterEqual()
+        
+        def _jax_wrapped_calc_leq_approx(a, b, param):
+            return jax_geq(-a, -b, param)
+        
+        return _jax_wrapped_calc_leq_approx, jax_param
     
-    def less(self, a, b):
-        return self.greater(-a, -b)
+    def less(self):
+        jax_gre, jax_param = self.greaterEqual()
 
-    def equal(self, a, b):
+        def _jax_wrapped_calc_less_approx(a, b, param):
+            return jax_gre(-a, -b, param)
+        
+        return _jax_wrapped_calc_less_approx, jax_param
+
+    def equal(self):
         warnings.warn('Using the replacement rule: '
                       'a == b --> sech^2(b - a)', stacklevel=2)
-        return 1.0 - jnp.square(jnp.tanh(self.weight * (b - a)))
+        
+        def _jax_wrapped_calc_equal_approx(a, b, param):
+            return 1.0 - jnp.square(jnp.tanh(param * (b - a)))
+        
+        new_param = ('weight_equal', self.weight)
+        return _jax_wrapped_calc_equal_approx, new_param
     
-    def notEqual(self, a, b):
-        return self.Not(self.equal(a, b))
-    
+    def notEqual(self):
+        _not = self.complement
+        jax_eq, jax_param = self.equal()
+        
+        def _jax_wrapped_calc_neq_approx(a, b, param):
+            return _not(jax_eq(a, b, param))
+
+        return _jax_wrapped_calc_neq_approx, jax_param
+        
     # ===========================================================================
     # special functions
     # ===========================================================================
      
-    def signum(self, x):
+    def signum(self):
         warnings.warn('Using the replacement rule: '
                       'signum(x) --> tanh(x)', stacklevel=2)
-        return jnp.tanh(self.weight * x)
+        
+        def _jax_wrapped_calc_signum_approx(x, param):
+            return jnp.tanh(param * x)
+        
+        new_param = ('weight_signum', self.weight)
+        return _jax_wrapped_calc_signum_approx, new_param
     
-    def _sawtooth(self, x):
-        d = self.eps
+    def _sawtooth(self, x, d):
         pi = jnp.pi
         trg = 1.0 - 2.0 * jnp.arccos((1.0 - d) * jnp.sin(pi * (x - 0.5))) / pi
         sqr = 2.0 * jnp.arctan(jnp.sin(pi * x) / d) / pi
         swt = (1.0 + trg * sqr) / 2.0
         return swt        
         
-    def floor(self, x):
+    def floor(self):
         warnings.warn('Using the replacement rule: '
                       'floor(x) --> x - sawtooth(x), where sawtooth is a '
                       'trigonometric approximation of the sawtooth function',
                       stacklevel=2)
-        return x - self._sawtooth(x)
+        
+        def _jax_wrapped_calc_floor_approx(x, param):
+            return x - self._sawtooth(x, param)
+        
+        new_param = ('error_floor', 1e-12)
+        return _jax_wrapped_calc_floor_approx, new_param
     
-    def ceil(self, x):
-        return -self.floor(-x)
+    def ceil(self):
+        jax_floor, jax_param = self.floor()
+        
+        def _jax_wrapped_calc_ceil_approx(x, param):
+            return -jax_floor(-x, param)
+        
+        return _jax_wrapped_calc_ceil_approx, jax_param
     
-    def round(self, x):
+    def round(self):
         warnings.warn('Using the replacement rule: '
                       'round(x) --> x', stacklevel=2)
-        return x
+        
+        def _jax_wrapped_calc_round_approx(x, param):
+            return x
+        
+        return _jax_wrapped_calc_round_approx, None
     
-    def mod(self, x, y):
-        return x - y * self.floor(x / y)
+    def mod(self):
+        jax_floor, jax_param = self.floor()
+        
+        def _jax_wrapped_calc_mod_approx(x, y, param):
+            return x - y * jax_floor(x / y, param)
+        
+        return _jax_wrapped_calc_mod_approx, jax_param
     
-    def floorDiv(self, x, y):
-        return self.floor(x / y)
+    def floorDiv(self):
+        jax_floor, jax_param = self.floor()
+        
+        def _jax_wrapped_calc_mod_approx(x, y, param):
+            return jax_floor(x / y, param)
+        
+        return _jax_wrapped_calc_mod_approx, jax_param
     
-    def sqrt(self, x):
+    def sqrt(self):
         warnings.warn('Using the replacement rule: '
                       'sqrt(x) --> sqrt(x + eps)', stacklevel=2)
-        return jnp.sqrt(x + self.eps)
+        
+        def _jax_wrapped_calc_sqrt_approx(x, param):
+            return jnp.sqrt(x + self.eps)
+        
+        return _jax_wrapped_calc_sqrt_approx, None
     
     # ===========================================================================
     # indexing
@@ -176,41 +293,60 @@ class FuzzyLogic:
         literals = jnp.broadcast_to(literals, shape=shape)
         return literals
     
-    def argmax(self, x, axis):
+    def argmax(self):
         warnings.warn('Using the replacement rule: '
                       f'argmax(x) --> sum(i * softmax(x[i]))', stacklevel=2)
-        prob_max = jax.nn.softmax(self.weight * x, axis=axis)
-        literals = FuzzyLogic._literals(prob_max.shape, axis=axis)
-        softargmax = jnp.sum(literals * prob_max, axis=axis)
-        trueargmax = jnp.argmax(x, axis=axis)
-        sample = softargmax + jax.lax.stop_gradient(trueargmax - softargmax)
-        return sample
+        
+        def _jax_wrapped_calc_argmax_approx(x, axis, param):
+            prob_max = jax.nn.softmax(param * x, axis=axis)
+            literals = FuzzyLogic._literals(prob_max.shape, axis=axis)
+            softargmax = jnp.sum(literals * prob_max, axis=axis)
+            trueargmax = jnp.argmax(x, axis=axis)
+            sample = softargmax + jax.lax.stop_gradient(trueargmax - softargmax)
+            return sample
+        
+        new_param = ('weight_argmax', self.weight)
+        return _jax_wrapped_calc_argmax_approx, new_param
     
-    def argmin(self, x, axis):
-        return self.argmax(-x, axis)
+    def argmin(self):
+        jax_argmax, jax_param = self.argmax()
+        
+        def _jax_wrapped_calc_argmin_approx(x, axis, param):
+            return jax_argmax(-x, axis, param)
+        
+        return _jax_wrapped_calc_argmin_approx, jax_param
     
     # ===========================================================================
     # control flow
     # ===========================================================================
      
-    def If(self, c, a, b):
+    def If(self):
         warnings.warn('Using the replacement rule: '
                       'if c then a else b --> c * a + (1 - c) * b', stacklevel=2)
-        return c * a + (1 - c) * b
+        
+        def _jax_wrapped_calc_if_approx(c, a, b, param):
+            return c * a + (1.0 - c) * b
+        
+        return _jax_wrapped_calc_if_approx, None
     
-    def Switch(self, pred, cases):
+    def Switch(self):
         warnings.warn('Using the replacement rule: '
                       'switch(pred) { cases } --> sum(cases[i] * (pred == i))',
                       stacklevel=2)    
-        pred = jnp.broadcast_to(pred[jnp.newaxis, ...], shape=cases.shape)
-        literals = FuzzyLogic._literals(cases.shape, axis=0)
-        proximity = -jnp.abs(pred - literals)
-        softcase = jax.nn.softmax(self.weight * proximity, axis=0)
-        softswitch = jnp.sum(cases * softcase, axis=0)
-        hardcase = jnp.argmax(proximity, axis=0)[jnp.newaxis, ...]        
-        hardswitch = jnp.take_along_axis(cases, hardcase, axis=0)[0, ...]
-        sample = softswitch + jax.lax.stop_gradient(hardswitch - softswitch)
-        return sample
+        
+        def _jax_wrapped_calc_switch_approx(pred, cases, param):
+            pred = jnp.broadcast_to(pred[jnp.newaxis, ...], shape=cases.shape)
+            literals = FuzzyLogic._literals(cases.shape, axis=0)
+            proximity = -jnp.abs(pred - literals)
+            softcase = jax.nn.softmax(param * proximity, axis=0)
+            softswitch = jnp.sum(cases * softcase, axis=0)
+            hardcase = jnp.argmax(proximity, axis=0)[jnp.newaxis, ...]        
+            hardswitch = jnp.take_along_axis(cases, hardcase, axis=0)[0, ...]
+            sample = softswitch + jax.lax.stop_gradient(hardswitch - softswitch)
+            return sample
+        
+        new_param = ('weight_switch', self.weight)
+        return _jax_wrapped_calc_switch_approx, new_param
     
     # ===========================================================================
     # random variables
@@ -221,34 +357,55 @@ class FuzzyLogic:
         sample = Gumbel01 + jnp.log(prob + self.eps)
         return sample
         
-    def bernoulli(self, key, prob):
+    def bernoulli(self):
         warnings.warn('Using the replacement rule: '
                       'Bernoulli(p) --> Gumbel-softmax(p)', stacklevel=2)
-        prob = jnp.stack([1.0 - prob, prob], axis=-1)
-        sample = self._gumbel_softmax(key, prob)
-        sample = self.argmax(sample, axis=-1)
-        return sample
+        
+        jax_gs = self._gumbel_softmax
+        jax_argmax, jax_param = self.argmax()
+        
+        def _jax_wrapped_calc_switch_approx(key, prob, param):
+            prob = jnp.stack([1.0 - prob, prob], axis=-1)
+            sample = jax_gs(key, prob)
+            sample = jax_argmax(sample, -1, param)
+            return sample
+        
+        return _jax_wrapped_calc_switch_approx, jax_param
     
-    def discrete(self, key, prob):
+    def discrete(self):
         warnings.warn('Using the replacement rule: '
                       'Discrete(p) --> Gumbel-softmax(p)', stacklevel=2)
-        sample = self._gumbel_softmax(key, prob) 
-        sample = self.argmax(sample, axis=-1)
-        return sample
+        
+        jax_gs = self._gumbel_softmax
+        jax_argmax, jax_param = self.argmax()
+        
+        def _jax_wrapped_calc_discrete_approx(key, prob, param):
+            sample = jax_gs(key, prob) 
+            sample = jax_argmax(sample, -1, param)
+            return sample
+        
+        return _jax_wrapped_calc_discrete_approx, jax_param
         
 
 # UNIT TESTS
 logic = FuzzyLogic()
+w = logic.weight
+w2 = 1e-12
 
 
 def _test_logical():
+    _and, _ = logic.And()
+    _not, _ = logic.Not()
+    _gre, _ = logic.greater()
+    _or, _ = logic.Or()
+    _if, _ = logic.If()
     
     # https://towardsdatascience.com/emulating-logical-gates-with-a-neural-network-75c229ec4cc9
     def test_logic(x1, x2):
-        q1 = logic.And(logic.greater(x1, 0), logic.greater(x2, 0))
-        q2 = logic.And(logic.Not(logic.greater(x1, 0)), logic.Not(logic.greater(x2, 0)))
-        cond = logic.Or(q1, q2)
-        pred = logic.If(cond, +1, -1)
+        q1 = _and(_gre(x1, 0, w), _gre(x2, 0, w), w)
+        q2 = _and(_not(_gre(x1, 0, w), w), _not(_gre(x2, 0, w), w), w)
+        cond = _or(q1, q2, w)
+        pred = _if(cond, +1, -1, w)
         return pred
     
     x1 = jnp.asarray([1, 1, -1, -1, 0.1, 15, -0.5]).astype(float)
@@ -257,10 +414,12 @@ def _test_logical():
 
 
 def _test_indexing():
+    _argmax, _ = logic.argmax()
+    _argmin, _ = logic.argmax()
 
     def argmaxmin(x):
-        amax = logic.argmax(x, axis=0)
-        amin = logic.argmin(x, axis=0)
+        amax = _argmax(x, 0, w)
+        amin = _argmin(x, 0, w)
         return amax, amin
         
     values = jnp.asarray([2., 3., 5., 4.9, 4., 1., -1., -2.])
@@ -270,20 +429,23 @@ def _test_indexing():
 
 
 def _test_control():
+    _switch, _ = logic.Switch()
+    
     pred = jnp.asarray(jnp.linspace(0, 2, 10))
     case1 = jnp.asarray([-10.] * 10)
     case2 = jnp.asarray([1.5] * 10)
     case3 = jnp.asarray([10.] * 10)
     cases = jnp.asarray([case1, case2, case3])
-    print(logic.Switch(pred, cases))
+    print(_switch(pred, cases, w))
 
 
 def _test_random():
     key = random.PRNGKey(42)
-
+    _bernoulli, _ = logic.bernoulli()
+    
     def bern(n):
         prob = jnp.asarray([0.3] * n)
-        sample = logic.bernoulli(key, prob)
+        sample = _bernoulli(key, prob, w)
         return sample
     
     samples = bern(5000)
@@ -291,10 +453,14 @@ def _test_random():
 
 
 def _test_rounding():
+    _floor, _ = logic.floor()
+    _ceil, _ = logic.ceil()
+    _mod, _ = logic.mod()
+    
     x = jnp.asarray([2.1, 0.5, 1.99, 2.0, -3.2, -0.1, -1.0, 23.01, -101.99, 200.01])
-    print(logic.floor(x))
-    print(logic.ceil(x))
-    print(logic.mod(x, 2.0))
+    print(_floor(x, w2))
+    print(_ceil(x, w2))
+    print(_mod(x, 2.0, w2))
 
 
 if __name__ == '__main__':

--- a/pyRDDLGym/Core/Jax/JaxRDDLModelError.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLModelError.py
@@ -1,0 +1,249 @@
+import jax
+import jax.numpy as jnp
+import jax.random as random
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+from typing import Callable, Dict, Tuple
+
+from pyRDDLGym.Core.Compiler.RDDLLiftedModel import RDDLLiftedModel
+from pyRDDLGym.Core.Jax.JaxRDDLCompiler import JaxRDDLCompiler
+from pyRDDLGym.Core.Jax.JaxRDDLBackpropPlanner import JaxRDDLCompilerWithGrad
+from pyRDDLGym.Core.Jax.JaxRDDLLogic import FuzzyLogic
+
+
+class Subplots:
+    
+    def __init__(self, num_plots: int,
+                 figsize: Tuple[int, int]) -> None:
+        self.num_plots = num_plots
+        
+        # sub-plots arranged in a square grid
+        self.dim = dim = np.floor(np.sqrt(num_plots)).astype(int) + 1
+        w, h = figsize
+        self.figure, self.axes = plt.subplots(
+            nrows=dim, ncols=dim, figsize=(w * dim, h * dim))
+        self.ix, self.iy = 0, 0
+    
+    def current_axis(self) -> matplotlib.axis.Axis:
+        return self.axes[self.iy, self.ix]
+    
+    def next_axis(self) -> None:
+        self.ix += 1
+        if self.ix >= self.dim:
+            self.ix = 0
+            self.iy += 1
+        
+    def blank_unused_axes(self) -> None:
+        while self.iy < self.dim:
+            self.current_axis().set_axis_off()
+            self.next_axis()
+            
+    def close(self) -> None:
+        plt.clf()
+        plt.close(self.figure)
+        del self.axes
+        del self.figure
+    
+    
+class JaxRDDLModelError:
+    '''Assists in the analysis of model error that arises from replacing exact
+    operations with fuzzy logic.
+    '''
+
+    def __init__(self, rddl: RDDLLiftedModel,
+                 test_policy: Callable,
+                 batch_size: int,
+                 rollout_horizon: int=None,
+                 logic: FuzzyLogic=FuzzyLogic()) -> None:
+        '''Creates a new instance to empirically estimate the model error.
+        
+        :param rddl: the RDDL domain to optimize
+        :param test_policy: policy to generate rollouts
+        :param batch_size: batch size
+        :param rollout_horizon: lookahead planning horizon: None uses the
+        horizon parameter in the RDDL instance
+        :param logic: a subclass of FuzzyLogic for mapping exact mathematical
+        operations to their differentiable counterparts
+        '''
+        self.rddl = rddl
+        self.test_policy = test_policy
+        self.batch_size = batch_size
+        if rollout_horizon is None:
+            rollout_horizon = rddl.horizon
+        self.horizon = rollout_horizon
+        self.logic = logic
+        
+        self._jax_compile()
+    
+    def _jax_compile(self):
+        rddl = self.rddl
+        n_batch = self.batch_size
+        test_policy = self.test_policy
+        
+        # Jax compilation of the differentiable RDDL for training
+        self.train_compiled = JaxRDDLCompilerWithGrad(
+            rddl=rddl,
+            logic=self.logic)
+        self.train_compiled.compile()
+        
+        # Jax compilation of the exact RDDL for testing
+        self.test_compiled = JaxRDDLCompiler(rddl=rddl)
+        self.test_compiled.compile()
+        
+        # roll-outs
+        def _jax_wrapped_train_policy(key, policy_params, step, subs):
+            test_actions = test_policy(key, policy_params, step, subs)
+            train_actions = jax.tree_map(
+                lambda x: x.astype(JaxRDDLCompiler.REAL),
+                test_actions)
+            return train_actions
+        
+        train_rollouts = self.train_compiled.compile_rollouts(
+            policy=_jax_wrapped_train_policy,
+            n_steps=self.horizon,
+            n_batch=n_batch)
+        
+        test_rollouts = self.test_compiled.compile_rollouts(
+            policy=test_policy,
+            n_steps=self.horizon,
+            n_batch=n_batch)
+        
+        # batched initial subs
+        def _jax_wrapped_batched_subs(subs): 
+            train_subs, test_subs = {}, {}
+            for (name, value) in subs.items():
+                value = jnp.asarray(value)[jnp.newaxis, ...]
+                train_value = jnp.repeat(value, repeats=n_batch, axis=0)
+                train_value = train_value.astype(JaxRDDLCompiler.REAL)
+                train_subs[name] = train_value
+                test_subs[name] = jnp.repeat(value, repeats=n_batch, axis=0)
+            for (state, next_state) in rddl.next_state.items():
+                train_subs[next_state] = train_subs[state]
+                test_subs[next_state] = test_subs[state]
+            return train_subs, test_subs
+        
+        # forward simulation
+        def _jax_wrapped_simulate_particles(
+                key, policy_params, subs, params_train, params_test):
+            
+            # generate rollouts from train and test model for the same inputs
+            train_subs, test_subs = _jax_wrapped_batched_subs(subs)
+            train_log = train_rollouts(key, policy_params, train_subs, params_train)
+            test_log = test_rollouts(key, policy_params, test_subs, params_test)
+            
+            # extract CPF and reward trajectories
+            train_fluents, test_fluents = {}, {}
+            train_fluents['reward'] = train_log['reward']
+            test_fluents['reward'] = test_log['reward']
+            for cpf in self.train_compiled.cpfs:
+                train_fluents[cpf] = train_log['pvar'][cpf]
+                test_fluents[cpf] = test_log['pvar'][cpf]
+            return train_fluents, test_fluents
+        
+        self.simulation = jax.jit(_jax_wrapped_simulate_particles)
+            
+    def sensitivity(self, key: random.PRNGKey,
+                    policy_params: Dict,
+                    param_ranges=np.linspace(1.0, 1000.0, num=100),
+                    subs: Dict=None,
+                    figsize: Tuple[int, int]=(6, 4)) -> None:
+        if subs is None:
+            subs = self.test_compiled.init_values
+        test_params = self.test_compiled.model_params
+        
+        # draw the error curves
+        curves = {}
+        for weight in param_ranges:
+            model_params = {name: weight 
+                            for name in self.train_compiled.model_params}
+            key, subkey = random.split(key)
+            train_fluents, test_fluents = self.simulation(
+                subkey, policy_params, subs, model_params, test_params)            
+            for name in train_fluents:
+                train_value = np.asarray(train_fluents[name], dtype=np.float64)
+                test_value = np.asarray(test_fluents[name], dtype=np.float64)
+                errors = np.mean(np.abs(train_value - test_value), axis=0)
+                errors = np.sum(errors, axis=0)  # sum across time
+                errors = np.ravel(errors, order='C')
+                curves.setdefault(name, []).append(errors)
+        
+        # plot each fluent component
+        subplots = Subplots(len(curves), figsize)
+        for (name, curve) in curves.items():
+            curve = np.asarray(curve)
+            grounded_names = self.rddl.grounded_names.get(name, ['reward'])
+            axis = subplots.current_axis()
+            for j in range(curve.shape[1]):
+                axis.plot(param_ranges, curve[:, j],
+                          label=grounded_names[j],
+                          linewidth=1)
+                axis.set_xlabel('model parameter')
+                axis.set_ylabel(f'{name} error')
+            subplots.next_axis()
+        subplots.blank_unused_axes()
+        plt.tight_layout()
+        subplots.figure.savefig('sensitivity.pdf')
+        subplots.close()
+    
+    def summarize(self, key: random.PRNGKey,
+                  policy_params: Dict,
+                  subs: Dict=None,
+                  figsize: Tuple[int, int]=(6, 3)) -> None:
+        
+        # get train and test particles
+        if subs is None:
+            subs = self.test_compiled.init_values
+        train_fluents, test_fluents = self.simulation(
+            key, policy_params, subs,
+            self.train_compiled.model_params,
+            self.test_compiled.model_params)
+    
+        # figure out # of plots required to plot each fluent component separately
+        sizes = {name: np.prod(value.shape[2:], dtype=int)
+                 for (name, value) in train_fluents.items()}
+        
+        # plot each fluent component
+        subplots = Subplots(sum(sizes.values()), figsize)
+        for (name, train_value) in train_fluents.items():
+            train_value = np.asarray(train_value, dtype=np.float64)
+            test_value = np.asarray(test_fluents[name], dtype=np.float64)
+            
+            # calculate statistics for fluent
+            train_value = train_value.reshape(*train_value.shape[:2], -1, order='C')
+            test_value = test_value.reshape(*test_value.shape[:2], -1, order='C')
+            train_mean = np.mean(train_value, axis=0)
+            test_mean = np.mean(test_value, axis=0)
+            train_std = np.std(train_value, axis=0)
+            test_std = np.std(test_value, axis=0)     
+            
+            grounded_names = list(self.rddl.ground_names(
+                name, self.rddl.param_types.get(name, [])))
+            assert len(grounded_names) == sizes[name]
+            
+            # plot each component j of fluent on a separate plot
+            for j in range(sizes[name]):
+                axis = subplots.current_axis()
+                
+                # show mean
+                xs = np.arange(train_mean.shape[0])
+                axis.plot(xs, train_mean[:, j], label='approx mean', color='blue')
+                axis.plot(xs, test_mean[:, j], label='true mean',
+                          linestyle='dashed', color='black')
+                
+                # show two standard deviations spread
+                axis.fill_between(xs, train_mean[:, j] - 2 * train_std[:, j],
+                                  train_mean[:, j] + 2 * train_std[:, j],
+                                  color='blue', alpha=0.15)
+                axis.fill_between(xs, test_mean[:, j] - 2 * test_std[:, j],
+                                  test_mean[:, j] + 2 * test_std[:, j],
+                                  color='black', alpha=0.15)
+                
+                axis.legend()
+                axis.set_xlabel('epoch')
+                axis.set_ylabel(grounded_names[j])
+                subplots.next_axis()                
+        subplots.blank_unused_axes()        
+        plt.tight_layout()
+        subplots.figure.savefig('summary.pdf')
+        subplots.close()

--- a/pyRDDLGym/JaxExample.py
+++ b/pyRDDLGym/JaxExample.py
@@ -2,9 +2,17 @@ import jax
 import sys
 
 from pyRDDLGym.Planner import JaxConfigManager
+from pyRDDLGym.Core.Compiler.RDDLDecompiler import RDDLDecompiler
   
 
 def slp_train(planner, **train_args):
+    model_params = planner.compiled.model_params
+    print(f'model_params = {model_params}')
+    ids = [int(key.split('_')[-1]) for key in model_params]
+    for _id in ids:
+        expr = planner.compiled.traced.lookup(_id)
+        print(f'\nid = {_id}:\n' + RDDLDecompiler().decompile_expr(expr))
+    
     print('\n' + 'training plan:')
     for callback in planner.optimize(**train_args):
         print('step={} train_return={:.6f} test_return={:.6f}'.format(
@@ -76,7 +84,7 @@ def main(env, replan):
         
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        args = [sys.argv[0]] + ['Wildfire replan']
+        args = [sys.argv[0]] + ['HVAC']
     else:
         args = sys.argv
     env = args[1]

--- a/pyRDDLGym/JaxExample.py
+++ b/pyRDDLGym/JaxExample.py
@@ -3,6 +3,7 @@ import sys
 
 from pyRDDLGym.Planner import JaxConfigManager
 from pyRDDLGym.Core.Compiler.RDDLDecompiler import RDDLDecompiler
+# from pyRDDLGym.Core.Jax.JaxRDDLModelError import JaxRDDLModelError
 
 
 def print_parameterized_exprs(planner):
@@ -23,6 +24,12 @@ def slp_train(planner, **train_args):
               callback['train_return'],
               callback['test_return']))
     params = callback['params']
+    
+    # key = jax.random.PRNGKey(42)
+    # error = JaxRDDLModelError(planner.rddl, planner.test_policy, 
+    #                           batch_size=64, logic=planner.logic)
+    # error.summarize(key, params)
+    # error.sensitivity(key, params)
     return params
 
 

--- a/pyRDDLGym/JaxExample.py
+++ b/pyRDDLGym/JaxExample.py
@@ -8,14 +8,14 @@ from pyRDDLGym.Core.Compiler.RDDLDecompiler import RDDLDecompiler
 def print_parameterized_exprs(planner):
     model_params = planner.compiled.model_params
     print(f'model_params = {model_params}')
-    ids = [int(key.split('_')[-1]) for key in model_params]
+    ids = planner.compiled.get_ids_of_parameterized_expressions()
     for _id in ids:
         expr = planner.compiled.traced.lookup(_id)
         print(f'\nid = {_id}:\n' + RDDLDecompiler().decompile_expr(expr))
     
     
 def slp_train(planner, **train_args):
-    # print_parameterized_exprs(planner)
+    print_parameterized_exprs(planner)
     print('\n' + 'training plan:')
     for callback in planner.optimize(**train_args):
         print('step={} train_return={:.6f} test_return={:.6f}'.format(

--- a/pyRDDLGym/JaxExample.py
+++ b/pyRDDLGym/JaxExample.py
@@ -3,9 +3,9 @@ import sys
 
 from pyRDDLGym.Planner import JaxConfigManager
 from pyRDDLGym.Core.Compiler.RDDLDecompiler import RDDLDecompiler
-  
 
-def slp_train(planner, **train_args):
+
+def print_parameterized_exprs(planner):
     model_params = planner.compiled.model_params
     print(f'model_params = {model_params}')
     ids = [int(key.split('_')[-1]) for key in model_params]
@@ -13,6 +13,9 @@ def slp_train(planner, **train_args):
         expr = planner.compiled.traced.lookup(_id)
         print(f'\nid = {_id}:\n' + RDDLDecompiler().decompile_expr(expr))
     
+    
+def slp_train(planner, **train_args):
+    # print_parameterized_exprs(planner)
     print('\n' + 'training plan:')
     for callback in planner.optimize(**train_args):
         print('step={} train_return={:.6f} test_return={:.6f}'.format(

--- a/pyRDDLGym/JaxExample.py
+++ b/pyRDDLGym/JaxExample.py
@@ -15,7 +15,7 @@ def print_parameterized_exprs(planner):
     
     
 def slp_train(planner, **train_args):
-    print_parameterized_exprs(planner)
+    # print_parameterized_exprs(planner)
     print('\n' + 'training plan:')
     for callback in planner.optimize(**train_args):
         print('step={} train_return={:.6f} test_return={:.6f}'.format(
@@ -87,7 +87,7 @@ def main(env, replan):
         
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        args = [sys.argv[0]] + ['HVAC']
+        args = [sys.argv[0]] + ['Traffic']
     else:
         args = sys.argv
     env = args[1]

--- a/pyRDDLGym/Planner/CartPole continuous.cfg
+++ b/pyRDDLGym/Planner/CartPole continuous.cfg
@@ -1,5 +1,5 @@
 [Environment]
-domain='cartpole continuous'
+domain='CartPole continuous'
 instance=0
 enforce_action_constraints=True
 

--- a/pyRDDLGym/Planner/MarsRover.cfg
+++ b/pyRDDLGym/Planner/MarsRover.cfg
@@ -1,5 +1,5 @@
 [Environment]
-domain='marsrover'
+domain='MarsRover'
 instance=0
 enforce_action_constraints=True
 

--- a/pyRDDLGym/Planner/MountainCar.cfg
+++ b/pyRDDLGym/Planner/MountainCar.cfg
@@ -1,5 +1,5 @@
 [Environment]
-domain='mountaincar'
+domain='MountainCar'
 instance=0
 enforce_action_constraints=True
 

--- a/pyRDDLGym/Planner/PowerGeneration replan.cfg
+++ b/pyRDDLGym/Planner/PowerGeneration replan.cfg
@@ -1,5 +1,5 @@
 [Environment]
-domain='powergen'
+domain='PowerGen continuous'
 instance=0
 enforce_action_constraints=True
 

--- a/pyRDDLGym/Planner/PowerGeneration.cfg
+++ b/pyRDDLGym/Planner/PowerGeneration.cfg
@@ -1,5 +1,5 @@
 [Environment]
-domain='powergen'
+domain='PowerGen continuous'
 instance=0
 enforce_action_constraints=True
 

--- a/pyRDDLGym/Planner/Traffic.cfg
+++ b/pyRDDLGym/Planner/Traffic.cfg
@@ -5,7 +5,7 @@ enforce_action_constraints=True
 
 [Model]
 logic='FuzzyLogic'
-logic_kwargs={'weight': 1000, 'error': 1e-6, 'debias': {'floor', 'argmax', 'Switch'}}
+logic_kwargs={'weight': 500, 'debias': {'ceil', 'argmax', 'Switch'}}
 tnorm='ProductTNorm'
 tnorm_kwargs={}
 

--- a/pyRDDLGym/Planner/Traffic.cfg
+++ b/pyRDDLGym/Planner/Traffic.cfg
@@ -1,11 +1,11 @@
 [Environment]
-domain='traffic'
+domain='Traffic'
 instance=0
 enforce_action_constraints=True
 
 [Model]
 logic='FuzzyLogic'
-logic_kwargs={'weight': 1000}
+logic_kwargs={'weight': 1000, 'error': 1e-6, 'debias': {'floor', 'argmax', 'Switch'}}
 tnorm='ProductTNorm'
 tnorm_kwargs={}
 
@@ -14,11 +14,12 @@ method='JaxStraightLinePlan'
 method_kwargs={}
 optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.2}
-batch_size_train=32
-batch_size_test=32
+batch_size_train=16
+batch_size_test=16
+clip_grad=1.0
 action_bounds={}
 
 [Training]
 key=42
-epochs=100
-step=1
+epochs=200
+step=2

--- a/pyRDDLGym/Planner/Traffic.cfg
+++ b/pyRDDLGym/Planner/Traffic.cfg
@@ -5,7 +5,7 @@ enforce_action_constraints=True
 
 [Model]
 logic='FuzzyLogic'
-logic_kwargs={'weight': 500, 'debias': {'ceil', 'argmax', 'Switch'}}
+logic_kwargs={'weight': 1000, 'debias': {'argmax', 'Switch'}}
 tnorm='ProductTNorm'
 tnorm_kwargs={}
 

--- a/pyRDDLGym/Planner/UAV continuous.cfg
+++ b/pyRDDLGym/Planner/UAV continuous.cfg
@@ -1,5 +1,5 @@
 [Environment]
-domain='uavcontinuous'
+domain='UAV continuous'
 instance=0
 enforce_action_constraints=True
 

--- a/pyRDDLGym/Planner/Wildfire replan.cfg
+++ b/pyRDDLGym/Planner/Wildfire replan.cfg
@@ -1,5 +1,5 @@
 [Environment]
-domain='wildfire'
+domain='Wildfire'
 instance=0
 enforce_action_constraints=True
 

--- a/pyRDDLGym/Planner/Wildfire.cfg
+++ b/pyRDDLGym/Planner/Wildfire.cfg
@@ -1,5 +1,5 @@
 [Environment]
-domain='wildfire'
+domain='Wildfire'
 instance=0
 enforce_action_constraints=True
 


### PR DESCRIPTION
- during tracing, each approximation can feed a model parameter (e.g. temperature) that is registered as part of the JAX computation graph
- the overall naming should generally follow \<variable type (e.g. temp, error)\>\_ \<node type (e.g. greater, floor...)\>\_\<node id\>: here the node id is the traversal order of the node in the computation graph: it is a unique identifier for each subexpression in the entire RDDL; RDDLTracedObjects that is returned from tracing can be queried with lookup(id) to recover the expression itself
- this dictionary could be modified during policy optimization or evaluation, and in principle can call jax.grad on a suitable loss function of this dictionary to optimize them
- currently, does not store computation results of intermediate expressions (this will need some deliberation to determine how to do this best)