### PR TITLE
Fixes #208

### DIFF
--- a/pyRDDLGym/Examples/ExampleManager.py
+++ b/pyRDDLGym/Examples/ExampleManager.py
@@ -92,7 +92,7 @@ class ExampleManager:
                 instances.append(file)
         return instances
 
-    def get_instance(self, num: int):
+    def get_instance(self, num: str):
         instance = f'instance{num}.rddl'
         if not os.path.exists(self.path_to_env + instance):
             raise RDDLInstanceNotExist(


### PR DESCRIPTION
Changes the function argument type in get_instance(self, num: int) in the ExampleManager class from 'int' to 'str'. This allows to load some of the instance files with characters in the filename, e.g. 'instance1c.rddl' in the MountainCar domain.