### PR TITLE
Fix ChartViz legend for unparameterized state-fluents, add '.DS_Store' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ VizRDDL/
 # Competition/
 TestingDomain/
 
+# macOS
+.DS_Store
+


### PR DESCRIPTION
Using the `ChartViz` visualizer e.g. for the SupplyChain domain one always gets the warning: 
`No artists with labels found to put in legend.  Note that artists whose label start with an underscore are ignored when legend() is called with no argument.`

As for unparameterized state-fluents no legend is necessary I added a simple `if-statement` in pyRDDLGym/Visualizer/ChartViz.py [line 173]:

> if var != '':
                    self._ax[y].legend(loc='upper right')
                    
Additionally, I added `.DS_Store` to the `.gitignore` to avoid automatically generated macOS files being pushed by mistake.