### PR TITLE
Log barrier method jax plan

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -179,7 +179,6 @@ and must specify the number of layers, the number of neurons, and an activation 
     optimizer_kwargs={'learning_rate': 0.01}
     batch_size_train=1
     batch_size_test=1
-    action_bounds={'power-x': (-0.0999, 0.0999), 'power-y': (-0.0999, 0.0999)}
 
     [Training]
     key=42
@@ -197,9 +196,12 @@ Box Constraints on Action Fluents
 
 Currently, the JAX planner supports two different kind of actions constraints: box constraints and concurrency constraints. 
 
-Box constraints are useful for bounding each action fluent independently into some range, 
-and can be specified by passing a dictionary of bounds for each action fluent into the ``action_bounds`` argument. 
-The syntax for specifying box constraints in the [Optimizer] section of the configuration file is:
+Box constraints are useful for bounding each action fluent independently into some range.
+Box constraints typically do not need to be specified manually, since they are automatically 
+parsed from the ``action_preconditions`` as defined in the RDDL domain description file.
+However, if the user wishes, it is possible to override these bounds
+by passing a dictionary of bounds for each action fluent into the ``action_bounds`` argument. 
+The syntax for specifying optional box constraints in the [Optimizer] section of the configuration file is:
 
 .. code-block:: shell
 	
@@ -207,11 +209,12 @@ The syntax for specifying box constraints in the [Optimizer] section of the conf
 	...
     action_bounds={ <action_name1>: (lower1, upper1), <action_name2>: (lower2, upper2), ... }
    
-where ``lower#`` and ``upper#`` can be any floating point value, including positive and negative infinity. 
-Passing ``None`` as a value to ``lower`` or ``upper`` indicates that a bound is not enforced, 
-i.e. ``(10.0, None)`` indicates an action must be at least 10.
+where ``lower#`` and ``upper#`` can be any list or nested list.
 
-The bounds on actions are enforced by default using the projected gradient method.
+By default, the box constraints on actions are enforced using the projected gradient method.
+An alternative approach is to map the trainable action parameters to the box via a differentiable transformation, 
+as described by `equation 6 in this paper <https://ojs.aaai.org/index.php/AAAI/article/view/4744>`_.
+In the JAX planner, it is possible to switch to the transformation method by setting ``wrap_non_bool = True``. 
 
 Boolean Actions
 -------------------
@@ -232,9 +235,6 @@ hyper-parameter that controls the sharpness of the approximation.
 At test time, the action is aliased by evaluating the expression :math:`a > 0.5`, or equivalently :math:`\theta > 0`.
 The use of sigmoid for boolean actions can be controlled by setting ``wrap_sigmoid = True``.
 
-Non-boolean actions can also be wrapped, bypassing the projected gradient trick, 
-by setting ``wrap_non_bool = True``. This follows `equation 6 in this paper <https://ojs.aaai.org/index.php/AAAI/article/view/4744>`_.
-   
 Concurrency Constraints on Action Fluents
 -------------------
 

--- a/pyRDDLGym/Core/Env/RDDLConstraints.py
+++ b/pyRDDLGym/Core/Env/RDDLConstraints.py
@@ -45,11 +45,15 @@ class RDDLConstraints:
 
         # actions and states bounds extraction for gym's action and state spaces
         # currently supports only linear inequality constraints
+        self._is_box_precond = []
         for precond in self.rddl.preconditions:
-            self._parse_bounds(precond, [], self.rddl.actions)
-            
+            is_box = self._parse_bounds(precond, [], self.rddl.actions)
+            self._is_box_precond.append(is_box)
+                    
+        self._is_box_invariant = []
         for invariant in self.rddl.invariants:
-            self._parse_bounds(invariant, [], self.rddl.states)
+            is_box = self._parse_bounds(invariant, [], self.rddl.states)
+            self._is_box_invariant.append(is_box)
 
         for (name, bounds) in self._bounds.items():
             RDDLSimulator._check_bounds(*bounds, f'Variable <{name}>', bounds)
@@ -70,20 +74,24 @@ class RDDLConstraints:
         if etype == 'aggregation' and op == 'forall':
             * pvars, arg = expr.args
             new_objects = objects + [pvar for (_, pvar) in pvars]
-            self._parse_bounds(arg, new_objects, search_vars)
+            return self._parse_bounds(arg, new_objects, search_vars)
         
         # for logical expression can only parse conjunction
         # same rationale as forall discussed above
         elif etype == 'boolean' and op == '^':
+            success = True
             for arg in expr.args:
-                self._parse_bounds(arg, objects, search_vars)
+                success_arg = self._parse_bounds(arg, objects, search_vars)
+                success = success and success_arg
+            return success
         
         # relational operation in constraint at the top level, i.e. constraint
         # LHS <= RHS for example
         elif etype == 'relational':
             var, lim, loc, active = self._parse_bounds_relational(
                 expr, objects, search_vars)
-            if var is not None and loc is not None: 
+            success = var is not None and loc is not None
+            if success: 
                 if objects:
                     if self.vectorized:
                         op = np.minimum if loc == 1 else np.maximum
@@ -100,7 +108,12 @@ class RDDLConstraints:
                 else:
                     op = min if loc == 1 else max
                     self._bounds[var][loc] = op(self._bounds[var][loc], lim)
-    
+            return success
+        
+        # not possible to parse as a box constraint
+        else:
+            return False
+               
     def _parse_bounds_relational(self, expr, objects, search_vars):
         left, right = expr.args    
         _, op = expr.etype
@@ -183,3 +196,12 @@ class RDDLConstraints:
     @bounds.setter
     def bounds(self, value):
         self._bounds = value
+    
+    @property
+    def is_box_preconditions(self):
+        return self._is_box_precond
+    
+    @property
+    def is_box_invariants(self):
+        return self._is_box_invariant
+    

--- a/pyRDDLGym/Core/Env/RDDLConstraints.py
+++ b/pyRDDLGym/Core/Env/RDDLConstraints.py
@@ -12,7 +12,7 @@ class RDDLConstraints:
     
     def __init__(self, simulator: RDDLSimulator,
                  max_bound: float=np.inf,
-                 inequality_tol: float=0.001,
+                 inequality_tol: float=1e-5,
                  vectorized: bool=False) -> None:
         '''Creates a new set of state and action constraints.
         

--- a/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
@@ -994,7 +994,7 @@ class JaxRDDLBackpropPlanner:
               f'    use_symlog      ={self.use_symlog_reward}\n'
               f'    lookahead       ={self.horizon}\n'
               f'    model relaxation={type(self.logic).__name__}\n'
-              f'    user action_bounds   ={self._action_bounds}\n'
+              f'    action_bounds   ={self._action_bounds}\n'
               f'    cpfs_no_gradient={self.cpfs_without_grad}\n'
               f'optimizer hyper-parameters:\n'
               f'    use_64_bit      ={self.use64bit}\n'
@@ -1199,6 +1199,9 @@ class JaxRDDLBackpropPlanner:
         
         # print summary of parameters:
         if verbose >= 1:
+            print('==============================================\n'
+                  'JAX PLANNER PARAMETER SUMMARY\n'
+                  '==============================================')
             self.summarize_hyperparameters()
             print(f'optimize() call hyper-parameters:\n'
                   f'    max_iterations     ={epochs}\n'

--- a/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
@@ -514,6 +514,7 @@ class JaxStraightLinePlan(JaxPlan):
                     actions[var] = action > bool_threshold
                 else:
                     action = _jax_non_bool_param_to_action(var, action, hyperparams)
+                    action = jnp.clip(action, *bounds[var])
                     if ranges[var] == 'int':
                         action = jnp.round(action).astype(compiled.INT)
                     actions[var] = action
@@ -854,9 +855,10 @@ class JaxDeepReactivePolicy(JaxPlan):
                 if prange == 'bool':
                     new_action = action > 0.5
                 elif prange == 'int':
+                    action = jnp.clip(action, *bounds[var])
                     new_action = jnp.round(action).astype(compiled.INT)
                 else:
-                    new_action = action
+                    new_action = jnp.clip(action, *bounds[var])
                 new_actions[var] = new_action
             return new_actions
         

--- a/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
@@ -304,6 +304,7 @@ class JaxPlan:
                 lower, upper = None, None
             else:
                 lower, upper = compiled.constraints.bounds[name]
+                lower, upper = user_bounds.get(name, (lower, upper))
                 lower_finite = np.isfinite(lower)
                 upper_finite = np.isfinite(upper)
                 bounds_safe[name] = (np.where(lower_finite, lower, 0.0),
@@ -314,11 +315,6 @@ class JaxPlan:
                     ~lower_finite & upper_finite,
                     ~lower_finite & ~upper_finite
                 ]
-                # lower, upper = user_bounds.get(name, (-jnp.inf, jnp.inf))
-                # if lower is None: 
-                #     lower = -jnp.inf
-                # if upper is None: 
-                #     upper = jnp.inf
             bounds[name] = (lower, upper)
             warnings.warn(f'Bounds of action fluent <{name}> set to '
                           f'{bounds[name]}', stacklevel=2)
@@ -913,7 +909,7 @@ class JaxRDDLBackpropPlanner:
                  batch_size_test: int=None,
                  rollout_horizon: int=None,
                  use64bit: bool=False,
-                 action_bounds: Dict[str, Tuple[float, float]]={},
+                 action_bounds: Dict[str, Tuple[np.ndarray, np.ndarray]]={},
                  optimizer: Callable[..., optax.GradientTransformation]=optax.rmsprop,
                  optimizer_kwargs: Dict[str, object]={'learning_rate': 0.1},
                  clip_grad: float=None,
@@ -997,7 +993,7 @@ class JaxRDDLBackpropPlanner:
               f'    use_symlog      ={self.use_symlog_reward}\n'
               f'    lookahead       ={self.horizon}\n'
               f'    model relaxation={type(self.logic).__name__}\n'
-              f'    action_bounds   ={self._action_bounds}\n'
+              f'    user action_bounds   ={self._action_bounds}\n'
               f'    cpfs_no_gradient={self.cpfs_without_grad}\n'
               f'optimizer hyper-parameters:\n'
               f'    use_64_bit      ={self.use64bit}\n'

--- a/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLBackpropPlanner.py
@@ -334,7 +334,7 @@ class JaxStraightLinePlan(JaxPlan):
     
     def __init__(self, initializer: initializers.Initializer=initializers.normal(),
                  wrap_sigmoid: bool=True,
-                 min_action_prob: float=1e-4,
+                 min_action_prob: float=1e-5,
                  wrap_non_bool: bool=False,
                  wrap_softmax: bool=False,
                  use_new_projection: bool=False,
@@ -421,7 +421,7 @@ class JaxStraightLinePlan(JaxPlan):
         def _jax_bool_action_to_param(var, action, hyperparams):
             if wrap_sigmoid:
                 weight = hyperparams[var]
-                return (-1.0 / weight) * jnp.log(1.0 / action - 1.0)
+                return (-1.0 / weight) * jnp.log1p(1.0 / action - 2.0)
             else:
                 return action
             

--- a/pyRDDLGym/Core/Jax/JaxRDDLCompiler.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLCompiler.py
@@ -26,6 +26,8 @@ from pyRDDLGym.Core.Compiler.RDDLLiftedModel import RDDLLiftedModel
 from pyRDDLGym.Core.Compiler.RDDLObjectsTracer import RDDLObjectsTracer
 from pyRDDLGym.Core.Compiler.RDDLValueInitializer import RDDLValueInitializer
 from pyRDDLGym.Core.Debug.Logger import Logger
+from pyRDDLGym.Core.Env.RDDLConstraints import RDDLConstraints
+from pyRDDLGym.Core.Simulator.RDDLSimulator import RDDLSimulatorPrecompiled
 
 
 class JaxRDDLCompiler:
@@ -207,14 +209,72 @@ class JaxRDDLCompiler:
     def _compile_reward(self, info):
         return self._jax(self.rddl.reward, info, dtype=self.REAL)
     
+    def _extract_inequality_constraint(self, expr):
+        result = []
+        etype, op = expr.etype
+        if etype == 'relational':
+            left, right = expr.args
+            if op == '<' or op == '<=':
+                result.append((right, left))
+            elif op == '>' or op == '>=':
+                result.append((left, right))
+        elif etype == 'boolean' and op == '^':
+            for arg in expr.args:
+                result.extend(self._extract_constraint(arg))
+        return result
+    
+    def _jax_inequality_constraints(self): 
+        rddl = self.rddl
+        
+        # extract the box constraints on actions
+        simulator = RDDLSimulatorPrecompiled(
+            rddl=rddl,
+            init_values=self.init_values,
+            levels=self.levels,
+            trace_info=self.traced)  
+        constraints = RDDLConstraints(simulator, vectorized=True)
+        
+        # extract the non-box constraints on actions
+        constraints = [constr 
+                       for (i, expr) in enumerate(rddl.preconditions)
+                       for constr in self._extract_inequality_constraint(expr)
+                       if not constraints.is_box_preconditions[i]]
+        
+        # compile them to JAX and write as h(s, a) >= 0
+        op = self.ARITHMETIC_OPS['-']        
+        jax_constrs = []
+        for (left, right) in constraints:
+            jax_lhs = self._jax(left, {})
+            jax_rhs = self._jax(right, {})
+            jax_constr = self._jax_binary(jax_lhs, jax_rhs, op, '', at_least_int=True)
+            jax_constrs.append(jax_constr)
+        return jax_constrs
+    
     def compile_rollouts(self, policy: Callable,
                          n_steps: int, 
                          n_batch: int,
-                         check_constraints: bool=False):
+                         check_constraints: bool=False,
+                         constraint_func: bool=False):
         '''Compiles the current RDDL into a wrapped function that samples multiple
         rollouts (state trajectories) in batched form for the given policy. The
         wrapped function takes the policy parameters and RNG key as input, and
         returns a dictionary of all logged information from the rollouts.
+        
+        constraint_func provides the option to compile nonlinear constraints:
+        
+            1. f(s, a) ?? g(s, a)
+            2. f1(s, a) ^ f2(s, a) ^ ... ?? g(s, a)
+            3. forall_{?p1, ...} f(s, a, ?p1, ...) ?? g(s, a) where f is of the
+               form 1 or 2 above.
+        
+        and where ?? is <, <=, > or >= into JAX expressions h(s, a) representing 
+        the constraints of the form: 
+            
+            h(s, a) >= 0
+                
+        for which a penalty or barrier-type method can be used to enforce 
+        constraint satisfaction. A list is returned containing values for all
+        non-box inequality constraints.
         
         :param policy: a Jax compiled function that takes the policy parameters, 
         decision epoch, state dict, and an RNG key and returns an action dict
@@ -223,6 +283,8 @@ class JaxRDDLCompiler:
         :param check_constraints: whether state, action and termination 
         conditions should be checked on each time step: this info is stored in the
         returned log and does not raise an exception
+        :param constraint_func: produces the h(s, a) function described above
+        in addition to the usual outputs
         '''
         NORMAL = JaxRDDLCompiler.ERROR_CODES['NORMAL']
         
@@ -230,6 +292,11 @@ class JaxRDDLCompiler:
         reward_fn, cpfs = self.reward, self.cpfs
         preconds, invariants, terminals = \
             self.preconditions, self.invariants, self.termination
+            
+        if constraint_func:
+            inequality_fns = self._jax_inequality_constraints()
+        else:
+            inequality_fns = None
         
         # do a single step update from the RDDL model
         def _jax_wrapped_single_step(key, policy_params, hyperparams, 
@@ -252,6 +319,14 @@ class JaxRDDLCompiler:
                     precond_check = jnp.logical_and(precond_check, sample)
                     errors |= err
             
+            # compute h(s, a) constraint functions
+            inequalities = []
+            if constraint_func:
+                for constraint in inequality_fns:
+                    sample, key, err = constraint(subs, model_params, key)
+                    inequalities.append(sample)
+                    errors |= err
+                
             # calculate CPFs in topological order
             for (name, cpf) in cpfs.items():
                 subs[name], key, err = cpf(subs, model_params, key)
@@ -281,6 +356,7 @@ class JaxRDDLCompiler:
                     terminated_check = jnp.logical_or(terminated_check, sample)
                     errors |= err
             
+            # prepare the return value
             log = {
                 'pvar': subs,
                 'action': actions,
@@ -289,7 +365,10 @@ class JaxRDDLCompiler:
                 'precondition': precond_check,
                 'invariant': invariant_check,
                 'termination': terminated_check
-            }
+            }            
+            if constraint_func:
+                log['inequalities'] = inequalities
+                
             return log, subs
         
         # do a batched step update from the RDDL model

--- a/pyRDDLGym/Core/Jax/JaxRDDLSimulator.py
+++ b/pyRDDLGym/Core/Jax/JaxRDDLSimulator.py
@@ -130,7 +130,7 @@ class JaxRDDLSimulator(RDDLSimulator):
             if not bool(sample):
                 if not silent:
                     raise RDDLActionPreconditionNotSatisfiedError(
-                        f'{loc} is not satisfied.')
+                        f'{loc} is not satisfied for actions {actions}.')
                 return False
         return True
     

--- a/pyRDDLGym/Core/Simulator/RDDLSimulator.py
+++ b/pyRDDLGym/Core/Simulator/RDDLSimulator.py
@@ -337,7 +337,8 @@ class RDDLSimulator:
             if not bool(sample):
                 if not silent:
                     raise RDDLActionPreconditionNotSatisfiedError(
-                        f'{loc} is not satisfied.\n' + print_stack_trace(precond))
+                        f'{loc} is not satisfied for actions {actions}\n' + 
+                        print_stack_trace(precond))
                 return False
         return True
     

--- a/pyRDDLGym/Core/Simulator/RDDLSimulator.py
+++ b/pyRDDLGym/Core/Simulator/RDDLSimulator.py
@@ -1,6 +1,6 @@
 import numpy as np
 np.seterr(all='raise')
-from typing import Dict, Union
+from typing import Dict, Set, Union
 
 from pyRDDLGym.Core.ErrorHandling.RDDLException import print_stack_trace
 from pyRDDLGym.Core.ErrorHandling.RDDLException import RDDLActionPreconditionNotSatisfiedError
@@ -1279,3 +1279,53 @@ def lngamma(x):
                         -1 + 1 / (99 * x_squared / 140) * (
                             1 + 1 / (910 * x_squared / 3))))))
 
+
+# A container class for compiling a simulator but from external info
+class RDDLSimulatorPrecompiled(RDDLSimulator):
+    
+    def __init__(self, rddl: PlanningModel, 
+                 init_values: Args, 
+                 levels: Dict[int, Set[str]], 
+                 trace_info: object,
+                 rng: np.random.Generator=np.random.default_rng(),
+                 keep_tensors: bool=False) -> None:
+        self.init_values = init_values
+        self.levels = levels
+        self.traced = trace_info
+        
+        super(RDDLSimulatorPrecompiled, self).__init__(
+            rddl=rddl, 
+            allow_synchronous_state=True,
+            rng=rng,
+            logger=None,
+            keep_tensors=keep_tensors)        
+    
+    def _compile(self):
+        rddl = self.rddl
+        
+        # compute dependency graph for CPFs and sort them by evaluation order   
+        self.cpfs = []  
+        for cpfs in self.levels.values():
+            for cpf in cpfs:
+                _, expr = rddl.cpfs[cpf]
+                prange = rddl.variable_ranges[cpf]
+                dtype = RDDLValueInitializer.NUMPY_TYPES.get(
+                    prange, RDDLValueInitializer.INT)
+                self.cpfs.append((cpf, expr, dtype))
+                
+        # initialize all fluent and non-fluent values        
+        self.subs = self.init_values.copy()
+        self.state = None  
+        self.noop_actions = {var: values
+                             for (var, values) in self.init_values.items()
+                             if rddl.variable_types[var] == 'action-fluent'}
+        self._pomdp = bool(rddl.observ)
+        
+        # cached for performance
+        self.invariant_names = [f'Invariant {i}' for i in range(len(rddl.invariants))]        
+        self.precond_names = [f'Precondition {i}' for i in range(len(rddl.preconditions))]
+        self.terminal_names = [f'Termination {i}' for i in range(len(rddl.terminals))]
+        
+        self.grounded_actionsranges = rddl.groundactionsranges()
+        self.grounded_noop_actions = rddl.ground_values_from_dict(self.noop_actions)
+        

--- a/pyRDDLGym/Core/Simulator/RDDLSimulator.py
+++ b/pyRDDLGym/Core/Simulator/RDDLSimulator.py
@@ -337,7 +337,7 @@ class RDDLSimulator:
             if not bool(sample):
                 if not silent:
                     raise RDDLActionPreconditionNotSatisfiedError(
-                        f'{loc} is not satisfied for actions {actions}\n' + 
+                        f'{loc} is not satisfied for actions {actions}.\n' + 
                         print_stack_trace(precond))
                 return False
         return True

--- a/pyRDDLGym/JaxPlanConfigs/CartPole_continuous_drp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/CartPole_continuous_drp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.001}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'force': (-10, 10)}
 clip_grad=1.0
 
 [Training]

--- a/pyRDDLGym/JaxPlanConfigs/CartPole_continuous_replan.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/CartPole_continuous_replan.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.1}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'force': (-10, 10)}
 rollout_horizon=30
 
 [Training]

--- a/pyRDDLGym/JaxPlanConfigs/CartPole_continuous_slp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/CartPole_continuous_slp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.001}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'force': (-10, 10)}
 clip_grad=1.0
 
 [Training]

--- a/pyRDDLGym/JaxPlanConfigs/HVAC_drp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/HVAC_drp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.0003}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'fan-in': (0.05001, None), 'heat-input': (0.0, None)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/HVAC_slp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/HVAC_slp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.01}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'fan-in': (0.05, None), 'heat-input': (0.0, None)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/MarsRover_drp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/MarsRover_drp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.01}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'power-x': (-0.0999, 0.0999), 'power-y': (-0.0999, 0.0999)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/MarsRover_slp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/MarsRover_slp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 1.0}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'power-x': (-0.0999, 0.0999), 'power-y': (-0.0999, 0.0999)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/MountainCar_slp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/MountainCar_slp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 1e8}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'action': (-1, 1)}
 clip_grad=1.0
 
 [Training]

--- a/pyRDDLGym/JaxPlanConfigs/PowerGen_continuous_drp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/PowerGen_continuous_drp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.001}
 batch_size_train=32
 batch_size_test=32
-action_bounds={'curProd': (0, 10)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/PowerGen_continuous_replan.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/PowerGen_continuous_replan.cfg
@@ -12,7 +12,6 @@ optimizer_kwargs={'learning_rate': 0.1}
 batch_size_train=32
 batch_size_test=32
 rollout_horizon=5
-action_bounds={'curProd': (0, 10)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/PowerGen_continuous_slp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/PowerGen_continuous_slp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.05}
 batch_size_train=32
 batch_size_test=32
-action_bounds={'curProd': (0, 10)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/Quadcopter_slp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/Quadcopter_slp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.01}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'power1': (-10000, 10000), 'power2': (-10000, 10000), 'power3': (-10000, 10000), 'power4': (-10000, 10000)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/Reservoir_continuous_replan.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/Reservoir_continuous_replan.cfg
@@ -12,7 +12,6 @@ optimizer_kwargs={'learning_rate': 0.1}
 batch_size_train=32
 batch_size_test=32
 rollout_horizon=5
-action_bounds={'release': (0, 200)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/Reservoir_continuous_slp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/Reservoir_continuous_slp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.1}
 batch_size_train=32
 batch_size_test=32
-action_bounds={'release': (0, 100)}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/Traffic_slp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/Traffic_slp.cfg
@@ -12,7 +12,6 @@ optimizer_kwargs={'learning_rate': 0.001}
 batch_size_train=16
 batch_size_test=16
 clip_grad=1.0
-action_bounds={}
 
 [Training]
 key=42

--- a/pyRDDLGym/JaxPlanConfigs/UAV_continuous_slp.cfg
+++ b/pyRDDLGym/JaxPlanConfigs/UAV_continuous_slp.cfg
@@ -11,7 +11,6 @@ optimizer='rmsprop'
 optimizer_kwargs={'learning_rate': 0.001}
 batch_size_train=1
 batch_size_test=1
-action_bounds={'set-acc': (-1, 1), 'set-phi': (-1, 1), 'set-theta': (-1, 1)}
 
 [Training]
 key=42


### PR DESCRIPTION
This overhauls the Jax compiler and planner as follows:
- action bounds are automatically computed but can be overridden in the config (this ensures backward compatibility)
- nonlinear constraint is exposed by the jax compiler in the form of h(s, a) >= 0 where h is returned over batches and time step in the log provided by compile_rollouts
- small improvements in numerical robustness in the jax planner